### PR TITLE
Use a shell script to restart ChaosBot instead of python

### DIFF
--- a/chaos.py
+++ b/chaos.py
@@ -19,7 +19,7 @@ from github_api import exceptions as gh_exc
 import patch
 
 
-if !os.path.isfile("usestartscript"):
+if not os.path.isfile("usestartscript"):
     open("usestartupscript", 'a').close()
     subprocess.call("start.sh", shell=True)
 

--- a/chaos.py
+++ b/chaos.py
@@ -19,6 +19,11 @@ from github_api import exceptions as gh_exc
 import patch
 
 
+if !os.path.isfile("usestartscript"):
+    open("usestartupscript", 'a').close()
+    subprocess.call("start.sh", shell=True)
+
+
 THIS_DIR = dirname(abspath(__file__))
 
 logging.basicConfig(level=logging.DEBUG)
@@ -38,7 +43,7 @@ def update_self_code():
 
 def restart_self():
     """ restart our process """
-    os.execl(sys.executable, sys.executable, *sys.argv)
+    sys.exit() # Restarting is handled in start.sh, allowing for more flexible things with stdout and stderr.
 
 
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+while true ; do
+    python3 chaos.py
+    echo "ChaosBot died, restarting in 30 seconds..."
+    sleep 30
+    echo "Restarting ChaosBot..."
+done

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,9 @@
 #! /bin/bash
 
-while true ; do
-    python3 chaos.py
-    echo "ChaosBot died, restarting in 30 seconds..."
-    sleep 30
-    echo "Restarting ChaosBot..."
-done
+python3 chaos.py
+echo "ChaosBot died, restarting in 30 seconds..."
+sleep 30
+echo "Restarting ChaosBot..."
+
+exec "$ScriptLoc" 
+# This is done with a exec instead of a while loop so that the script will be reloaded if it is modified.


### PR DESCRIPTION
This allows things such as redirecting stdout and stderr to a file, as well as making certain shell actions easier.

In the future, https://docs.python.org/2/library/simplehttpserver.html or the such can be used to host the stdout of the bot for easier debugging. 

Do also note that this is mostly untested, and should be reviewed before being merged.