### PR TITLE
Remove comment reaction voting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ the imagination of the open source community.
 
 Votes on a PR are sourced through the following mechanisms:
 * A comment that contains :+1: or :-1: somewhere in the body
-* A :+1: or :-1: reaction on a comment or the PR itself
+* A :+1: or :-1: reaction on the PR itself
 * An accept/reject [pull request review](https://help.github.com/articles/about-pull-request-reviews/)
 * The PR itself counts as :+1: from the owner
 

--- a/github_api/voting.py
+++ b/github_api/voting.py
@@ -56,10 +56,13 @@ def get_pr_comment_votes_all(api, urn, pr_num, since):
         # ------------|---------------|---------------
         # old comment | doesn't count | doesn't count
         # new comment | not possible  | counts
+        '''
+        Removed in response to issue #21
         reaction_votes = get_comment_reaction_votes(api, urn,
                 comment["id"], since)
         for reaction_owner, vote in reaction_votes:
             yield reaction_owner, vote
+        '''
 
     # we consider the pr itself to be the "first comment."  in the web ui, it
     # looks like a comment, complete with reactions, so let's treat it like a


### PR DESCRIPTION
In response to #21, prevent thumbs reactions from counting on comments while still allowing the comment itself to vote if it contains a thumb.

Agreement with a comment does not necessarily constitute agreement with the PR. If you +1 react to a negative comment, it counts as an upvote even if you only meant to agree with the negative comment. Likewise, disagreement with a comment does not necessarily constitute disagreement with the PR. If a comment suggests something that shouldn't be added to the PR, an appropriate reaction would be to -1 it. However, this also affects the PR's approval rating even if you didn't mean to do this.

Since comment reactions can have unintended consequences, let's just get rid of them. It's obvious that a +1 or -1 in the body of a comment is reacting to the PR, so we'll keep that in.

Addendum: It also becomes a lot easier to keep track of votes this way since all voting is done on the parent PR comment (with a few in the body of the following comments).