### PR TITLE
Create .hgignore

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,4 @@
+*.pyc
+.DS_Store
+github_pat.secret
+.gitignore


### PR DESCRIPTION
Mercurial is a superior VCS system nobody uses, let's make it possible to change this repository into Mercurial repository. Yay!