### PR TITLE
Add .venv to .gitignore for virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.pyc
 .DS_Store
+.venv
 github_pat.secret
-


### PR DESCRIPTION
Ignore .venv directory.

virtualenv allows installing python dependencies in an
isolated environment, e.g.:

    pip install virtualenv
    virtualenv .venv
    source .venv/bin/activate
    pip install -r requirements.txt
    # play with chaos
    deactivate