### PR TITLE
Organize startup mechanism

### DIFF
--- a/chaos.py
+++ b/chaos.py
@@ -1,7 +1,6 @@
 import time
 import os
 import sys
-import sh
 from os.path import dirname, abspath, join
 import logging
 import threading
@@ -44,15 +43,10 @@ class HTTPServerRequestHandler(http.server.BaseHTTPRequestHandler):
 
         self.wfile.write(random.choice(fortunes).encode("utf8"))
 
-def update_self_code():
-    """ pull the latest commits from master """
-    sh.git.pull("origin", "master")
-
-
 def restart_self():
-    """ restart our process """
-    os.execl(sys.executable, sys.executable, *sys.argv)
-
+    """ restart chaos """
+    startup_path = join(dirname(__file__), "startup.sh")
+    os.execl(startup_path, startup_path)
 
 def http_server():
     s = http.server.HTTPServer(('', 8080), HTTPServerRequestHandler)
@@ -61,10 +55,6 @@ def http_server():
 def start_http_server():
     http_server_thread = threading.Thread(target=http_server)
     http_server_thread.start()
-
-def install_requirements():
-    """install or update requirements"""
-    os.system("pip install -r requirements.txt")
 
 if __name__ == "__main__":
     logging.info("starting up and entering event loop")
@@ -121,8 +111,6 @@ if __name__ == "__main__":
         # we approved a PR, restart
         if needs_update:
             logging.info("updating code and requirements and restarting self")
-            update_self_code()
-            install_requirements()
             restart_self()
 
         logging.info("sleeping for %d seconds", settings.SLEEP_TIME)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ packaging==16.8
 pyparsing==2.2.0
 python-dateutil==2.6.0
 requests==2.14.2
-sh==1.12.13
 six==1.10.0

--- a/startup.d/10-git-pull.sh
+++ b/startup.d/10-git-pull.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+git pull

--- a/startup.d/30-install-requirements.sh
+++ b/startup.d/30-install-requirements.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+pip install -r requirements.txt

--- a/startup.d/90-chaos.sh
+++ b/startup.d/90-chaos.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+python chaos.py

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+for file in startup.d/*; do
+  [[ -f "$file" && -x "$file" ]] && "$file"
+done


### PR DESCRIPTION
By placing everything in a directory (`startup.d`), we can eliminate a lot of merge conflicts and help streamline the process. This is essential if we want to expand chaosbot's functionality in the future.