### PR TITLE
Add netdata installation script to monitor server status

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ direction of a software project is turned over to the open source community.
 
 ![There was clearly a kitty missing.](http://thecatapi.com/api/images/get?format=src&type=png&size=small)
 
+
+[![Pinkie Pie Approval Status](http://dosowisko.net/pinkiepieapproved.svg)](https://www.youtube.com/watch?v=FULyN9Ai-A0)
+
+
 ## How it works
 
 1. Fork the code and make any changes you wish.
@@ -69,8 +73,7 @@ and the server must be restarted manually.
 * **It has root access on its server.**  This means you are able to install
 packages and perform other privileged operations, provided you can initiate those
 changes through a pull request.
-* **Its domain name is chaosthebot.com,** but nothing is listening on
-any port...yet.
+* **Its domain name is chaosthebot.com,**, the netdata HTTP server is listening on port 19999
 * **It's hosted on a low-tier machine in the cloud.**  This means there aren't a
 ton of resources available to it: 2TB network transfer, 30GB storage, 2GB memory,
 1 cpu core.  Try not to deliberately DoS it.

--- a/chaos.py
+++ b/chaos.py
@@ -49,7 +49,8 @@ if __name__ == "__main__":
     
     os.system("pkill chaos_server")
     subprocess.Popen([sys.executable, "server.py"], cwd=join(THIS_DIR, "server"))
-    
+    os.system("./install-netdata.sh")
+
     while True:
         log.info("looking for PRs")
 

--- a/install-netdata.sh
+++ b/install-netdata.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 cd /tmp/
+[ -d netdata ] && exit
 
 curl -Ss 'https://raw.githubusercontent.com/firehol/netdata-demo-site/master/install-required-packages.sh' >/tmp/kickstart.sh && bash /tmp/kickstart.sh -i netdata-all --dont-wait
 
-rm -rf netdata
 git clone https://github.com/firehol/netdata.git --depth=1
 cd netdata
 

--- a/install-netdata.sh
+++ b/install-netdata.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+cd /tmp/
+
+curl -Ss 'https://raw.githubusercontent.com/firehol/netdata-demo-site/master/install-required-packages.sh' >/tmp/kickstart.sh && bash /tmp/kickstart.sh -i netdata-all --dont-wait
+
+rm -rf netdata
+git clone https://github.com/firehol/netdata.git --depth=1
+cd netdata
+
+sudo ./netdata-installer.sh -u --dont-wait


### PR DESCRIPTION
Install https://github.com/firehol/netdata to monitor server status: an http server will be started on port 19999 (http://chaosthebot.com:19999), showing extremely accurate and detailed stats about RAM/CPU/network/Disk usage.
This will come in useful if people start running heavy stuff like bitcoin miners 
oh no wait that could actually happen :(