### PR TITLE
Chaosbot follows github users

### DIFF
--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -41,6 +41,11 @@ def poll_pull_requests():
                 continue
 
             gh.prs.label_pr(api, settings.URN, pr_num, ["accepted"])
+
+            # chaosbot rewards merge owners with a follow
+            pr_owner = pr["user"]["login"]
+            gh.users.follow_user(api, pr_owner)
+
             needs_update = True
 
         else:

--- a/github_api/users.py
+++ b/github_api/users.py
@@ -4,3 +4,6 @@ def get_user(api, user):
     data = api("get", path)
     return data
 
+def follow_user(api, user):
+    follow_path = "/user/following/{user}".format(user=user)
+    follow_resp = api("PUT", follow_path)


### PR DESCRIPTION
Upon a merge, chaosbot follows the GitHub account of the pull request author.  Cleaned up and rebased.