### PR TITLE
Fix voting window

### DIFF
--- a/github_api/voting.py
+++ b/github_api/voting.py
@@ -196,8 +196,8 @@ def get_voting_window(now):
     lhour = local.hour
 
     hours = settings.DEFAULT_VOTE_WINDOW
-    if (settings.AFTER_HOURS_START >= lhour or
-            settings.AFTER_HOURS_END <= lhour):
+    if (lhour >= settings.AFTER_HOURS_START or
+            lhour <= settings.AFTER_HOURS_END):
         hours = settings.AFTER_HOURS_VOTE_WINDOW
 
     seconds = hours * 60 * 60


### PR DESCRIPTION
It was backwards.

The settings should probably be renamed too, but I don't know what they should be named.