### PR TITLE
Post current voting status to GitHub Status API

### DIFF
--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -14,15 +14,20 @@ def poll_pull_requests():
     __log.info("looking for PRs")
 
     api = gh.API(settings.GITHUB_USER, settings.GITHUB_SECRET)
+
+    # get voting window
     now = arrow.utcnow()
     voting_window = gh.voting.get_voting_window(now)
-    prs = gh.prs.get_ready_prs(api, settings.URN, voting_window)
+
+    # get all ready prs (disregarding of the voting window)
+    prs = gh.prs.get_ready_prs(api, settings.URN, 0)
 
     needs_update = False
     for pr in prs:
         pr_num = pr["number"]
         __log.info("processing PR #%d", pr_num)
 
+        # gather all current votes
         votes = gh.voting.get_votes(api, settings.URN, pr)
 
         # is our PR approved or rejected?
@@ -30,33 +35,47 @@ def poll_pull_requests():
         threshold = gh.voting.get_approval_threshold(api, settings.URN)
         is_approved = vote_total >= threshold
 
+        # is our PR in voting window?
+        in_window = gh.prs.is_pr_in_voting_window(pr, voting_window)
+
         if is_approved:
-            __log.info("PR %d approved for merging!", pr_num)
-            try:
-                gh.prs.merge_pr(api, settings.URN, pr, votes, vote_total,
-                        threshold)
-            # some error, like suddenly there's a merge conflict, or some
-            # new commits were introduced between findint this ready pr and
-            # merging it
-            except gh.exceptions.CouldntMerge:
-                __log.info("couldn't merge PR %d for some reason, skipping",
-                        pr_num)
-                gh.prs.label_pr(api, settings.URN, pr_num, ["can't merge"])
-                continue
+            __log.info("PR %d status: will be approved", pr_num)
 
-            gh.prs.label_pr(api, settings.URN, pr_num, ["accepted"])
+            gh.prs.post_accepted_status(api, settings.URN, pr, voting_window, votes, vote_total, threshold)
 
-            # chaosbot rewards merge owners with a follow
-            pr_owner = pr["user"]["login"]
-            gh.users.follow_user(api, pr_owner)
+            if in_window:
+                __log.info("PR %d approved for merging!", pr_num)
 
-            needs_update = True
+                try:
+                    gh.prs.merge_pr(api, settings.URN, pr, votes, vote_total,
+                            threshold)
+                # some error, like suddenly there's a merge conflict, or some
+                # new commits were introduced between findint this ready pr and
+                # merging it
+                except gh.exceptions.CouldntMerge:
+                    __log.info("couldn't merge PR %d for some reason, skipping",
+                            pr_num)
+                    gh.prs.label_pr(api, settings.URN, pr_num, ["can't merge"])
+                    continue
+
+                gh.prs.label_pr(api, settings.URN, pr_num, ["accepted"])
+
+                # chaosbot rewards merge owners with a follow
+                pr_owner = pr["user"]["login"]
+                gh.users.follow_user(api, pr_owner)
+
+                needs_update = True
 
         else:
-            __log.info("PR %d rejected, closing", pr_num)
-            gh.comments.leave_reject_comment(api, settings.URN, pr_num)
-            gh.prs.label_pr(api, settings.URN, pr_num, ["rejected"])
-            gh.prs.close_pr(api, settings.URN, pr)
+            __log.info("PR %d status: will be rejected", pr_num)
+
+            gh.prs.post_rejected_status(api, settings.URN, pr, voting_window, votes, vote_total, threshold)
+
+            if in_window:
+                __log.info("PR %d rejected, closing", pr_num)
+                gh.comments.leave_reject_comment(api, settings.URN, pr_num)
+                gh.prs.label_pr(api, settings.URN, pr_num, ["rejected"])
+                gh.prs.close_pr(api, settings.URN, pr)
 
     # we approved a PR, restart
     if needs_update:

--- a/github_api/misc.py
+++ b/github_api/misc.py
@@ -1,3 +1,8 @@
 
 def dt_to_github_dt(dt):
     return dt.isoformat() + "Z"
+
+def seconds_to_human(seconds):
+    m, s = divmod(seconds, 60)
+    h, m = divmod(m, 60)
+    return "%d:%02d" % (h, m)

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -19,31 +19,26 @@ def merge_pr(api, urn, pr, votes, total, threshold):
     if record:
         record = "Vote record:\n" + record
 
-    vfor = sum(v for v in votes.values() if v > 0)
-    vagainst = abs(sum(v for v in votes.values() if v < 0))
+    votes_summary = formatted_votes_summary(votes, total, threshold)
 
     pr_url = "https://github.com/{urn}/pull/{pr}".format(urn=urn, pr=pr_num)
 
-    title = "merging PR #{num}: {pr_title}".format(num=pr_num, pr_title=pr_title) 
+    title = "merging PR #{num}: {pr_title}".format(num=pr_num, pr_title=pr_title)
     desc = """
 {pr_url}: {pr_title}
 
 Description:
 {pr_description}
 
-:ok_woman: PR passed with a vote of {vfor} for and {vagainst} against, with a
-weighted total of {total:.1f} and a threshold of {threshold:.1f}.
+ok_woman: PR passed {summary}.
 
 {record}
 """.strip().format(
-    vfor=vfor,
-    vagainst=vagainst,
-    total=total,
-    threshold=threshold,
-    record=record,
     pr_url=pr_url,
     pr_title=pr_title,
     pr_description=pr_description,
+    summary=votes_summary,
+    record=record,
     )
 
     data = {
@@ -69,11 +64,28 @@ weighted total of {total:.1f} and a threshold of {threshold:.1f}.
             raise
 
 
+def formatted_votes_summary(votes, total, threshold):
+    vfor = sum(v for v in votes.values() if v > 0)
+    vagainst = abs(sum(v for v in votes.values() if v < 0))
+
+    return "with a vote of {vfor} for and {vagainst} against, with a weighted total of {total:.1f} and a threshold of {threshold:.1f}" \
+        .strip().format(vfor=vfor, vagainst=vagainst, total=total, threshold=threshold)
+
+
+def formatted_votes_short_summary(votes, total, threshold):
+    vfor = sum(v for v in votes.values() if v > 0)
+    vagainst = abs(sum(v for v in votes.values() if v < 0))
+
+    return "vote: {vfor}-{vagainst}, weighted total: {total:.1f}, threshold: {threshold:.1f}" \
+        .strip().format(vfor=vfor, vagainst=vagainst, total=total, threshold=threshold)
+
+
 def label_pr(api, urn, pr, labels):
     """ apply an issue label to a pr """
     path = "/repos/{urn}/issues/{pr}/labels".format(urn=urn, pr=pr)
     data = labels
     resp = api("POST", path, json=data)
+
 
 def close_pr(api, urn, pr):
     """ https://developer.github.com/v3/pulls/#update-a-pull-request """
@@ -82,6 +94,7 @@ def close_pr(api, urn, pr):
         "state": "closed",
     }
     return api("patch", path, json=data)
+
 
 def get_pr_last_updated(pr_data):
     """ a helper for finding the utc datetime of the last pr branch
@@ -122,7 +135,7 @@ def get_ready_prs(api, urn, window):
         # i would like to do this, but it turns out, the "mergeable" field only
         # exists on individual prs fetched through the api, not prs in paginated
         # form
-        #mergeable = pr["mergeable"] is True
+        # mergeable = pr["mergeable"] is True
 
         is_wip = "WIP" in pr["title"]
 
@@ -133,6 +146,17 @@ def get_ready_prs(api, urn, window):
             # directly
             if get_is_mergeable(api, urn, pr_num):
                 yield pr
+
+
+def voting_window_remaining_seconds(pr, window):
+    now = arrow.utcnow()
+    updated = get_pr_last_updated(pr)
+    delta = (now - updated).total_seconds()
+    return window - delta
+
+
+def is_pr_in_voting_window(pr, window):
+    return voting_window_remaining_seconds(pr, window) <= 0
 
 
 def get_pr_reviews(api, urn, pr_num):
@@ -149,6 +173,7 @@ def get_pr_reviews(api, urn, pr_num):
 def get_is_mergeable(api, urn, pr_num):
     return get_pr(api, urn, pr_num)["mergeable"] is True
 
+
 def get_pr(api, urn, pr_num):
     """ helper for fetching a pr.  necessary because the "mergeable" field does
     not exist on prs that come back from paginated endpoints, so we must fetch
@@ -156,6 +181,7 @@ def get_pr(api, urn, pr_num):
     path = "/repos/{urn}/pulls/{pr}".format(urn=urn, pr=pr_num)
     pr = api("get", path)
     return pr
+
 
 def get_open_prs(api, urn):
     params = {
@@ -176,3 +202,35 @@ def get_reactions_for_pr(api, urn, pr):
     for reaction in reactions:
         yield reaction
 
+
+def post_accepted_status(api, urn, pr, voting_window, votes, total, threshold):
+    sha = pr["head"]["sha"]
+
+    remaining_seconds = voting_window_remaining_seconds(pr, voting_window)
+    remaining_human = misc.seconds_to_human(remaining_seconds)
+    votes_summary = formatted_votes_short_summary(votes, total, threshold)
+
+    post_status(api, urn, sha, "success",
+                "remaining: {time}, {summary}".format(time=remaining_human, summary=votes_summary))
+
+
+def post_rejected_status(api, urn, pr, voting_window, votes, total, threshold):
+    sha = pr["head"]["sha"]
+
+    remaining_seconds = voting_window_remaining_seconds(pr, voting_window)
+    remaining_human = misc.seconds_to_human(remaining_seconds)
+    votes_summary = formatted_votes_short_summary(votes, total, threshold)
+
+    post_status(api, urn, sha, "failure",
+                "remaining: {time}, {summary}".format(time=remaining_human, summary=votes_summary))
+
+
+def post_status(api, urn, sha, state, description):
+    """ apply an issue label to a pr """
+    path = "/repos/{urn}/statuses/{sha}".format(urn=urn, sha=sha)
+    data = {
+        "state": state,
+        "description": description,
+        "context": "chaosbot"
+    }
+    api("POST", path, json=data)


### PR DESCRIPTION
Re-implementation of #113

Posts a status update on a PR every cron cycle, resulting in green or red checkmarks:

![image](https://cloud.githubusercontent.com/assets/205834/26394306/c8eafe94-406c-11e7-96ff-75c7d1dd8d2a.png)

![image](https://cloud.githubusercontent.com/assets/205834/26394377/0f285168-406d-11e7-9c42-67c99e47bb3b.png)

It actually saves the status on the last commit, so a history is preserved when new commits are added to the PR:

![image](https://cloud.githubusercontent.com/assets/205834/26394493/73bb96d0-406d-11e7-8cef-dfd71944d88a.png)

