### PR TITLE
Voting threshold

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -43,9 +43,8 @@ FOLLOWER_LOG_BASE = 30
 
 # for a pr to be merged, the vote total must have at least this fraction of the
 # number of watchers in order to pass.  this is to prevent early manipulation of
-# the project by requiring some basic consensus.  i'm not sure its necessary, so
-# it's 0
-MIN_VOTE_WATCHERS = 0
+# the project by requiring some basic consensus.
+MIN_VOTE_WATCHERS = 0.01
 
 # unauthenticated api requests get 60 requests/hr, so we need to get as much
 # data from each request as we can.  apparently 100 is the max number of pages

--- a/settings.py
+++ b/settings.py
@@ -31,14 +31,14 @@ AFTER_HOURS_START = 22
 # The hour when the after hours end
 AFTER_HOURS_END = 10
 
-OWNER = "chaosbot"
-PROJECT = "Chaos"
+OWNER = GITHUB_USER
+PROJECT = "chaos"
 URN = OWNER + "/" + PROJECT
 
-# voter controls below
-## how old do they have to be for their vote to count?
-MIN_VOTER_AGE = 1 * 30 * 24 * 60 * 60 # 1 month
-## at what follower count does a voter's social weight become 1.0?
+# how old do voters have to be for their vote to count?
+MIN_VOTER_AGE = 1 * 30 * 24 * 60 * 60  # 1 month
+
+# at what follower count does a voter's social weight become 1.0?
 FOLLOWER_LOG_BASE = 30
 
 # for a pr to be merged, the vote total must have at least this fraction of the

--- a/settings.py
+++ b/settings.py
@@ -38,9 +38,6 @@ URN = OWNER + "/" + PROJECT
 # how old do voters have to be for their vote to count?
 MIN_VOTER_AGE = 1 * 30 * 24 * 60 * 60  # 1 month
 
-# at what follower count does a voter's social weight become 1.0?
-FOLLOWER_LOG_BASE = 30
-
 # for a pr to be merged, the vote total must have at least this fraction of the
 # number of watchers in order to pass.  this is to prevent early manipulation of
 # the project by requiring some basic consensus.


### PR DESCRIPTION
There should be a voting threshold (it's actually a threshold on the votes _difference_).

Set to 1% of repo followers (currently, that means the difference between 👍 and 👎 should be at least 12).

Prevents things like #138 and #48.

Maybe we can change this later to use a percentage of active contributors instead of (possibly passive) stargazers? Not sure how to calculate that atm though.