### PR TITLE
Fix provisioning for Vagrant at python3-pip installation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
   # Ensure basic python requirements are initialized.
   config.vm.provision "shell", inline: <<-SHELL2
     cd /vagrant
-    apt-get install python3-pip
+    apt-get install -y python3-pip
     pip3 install -r requirements.txt
   SHELL2
 


### PR DESCRIPTION
Vagrant provision was failing due to lack of `-y` flag for installation of `python3-pip` via `apt-get`. 