### PR TITLE
adding nginx proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 .venv
 github_pat.secret
+*.swp
+.vagrant/

--- a/puppet/manifests/sites.pp
+++ b/puppet/manifests/sites.pp
@@ -1,3 +1,4 @@
 node default {
     class{'chaos_system_packages':}
+    class{'chaos_system_packages::setup_nginx':}
 }

--- a/puppet/modules/chaos_system_packages/manifests/setup_nginx.pp
+++ b/puppet/modules/chaos_system_packages/manifests/setup_nginx.pp
@@ -1,0 +1,8 @@
+class chaos_system_packages::setup_nginx {
+	class {'nginx': }
+	
+	nginx::resource::server { 'chaosthebot.com' :
+		listen_port => 80,
+		proxy => 'http://localhost:8080'
+	}
+}

--- a/puppet/pullForge.sh
+++ b/puppet/pullForge.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+puppet module install puppetlabs-nginx --modulepath=$PWD/modules

--- a/server/server.py
+++ b/server/server.py
@@ -12,7 +12,7 @@ def set_proc_name(newname):
 set_proc_name("chaos_server")
 
 #start server on port 80
-PORT = 80
+PORT = 8080
 Handler = http.server.SimpleHTTPRequestHandler
 
 class NoTimeWaitTCPServer(socketserver.TCPServer):

--- a/startup.d/40-run-puppet.sh
+++ b/startup.d/40-run-puppet.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 cd puppet
+./pullForge.sh
 puppet apply --verbose --modulepath=$PWD/modules/ $PWD/manifests/


### PR DESCRIPTION
biggest changes w/ this PR are the following:

1. moving server.py to port 8080
2. added puppet modules (bulk of new files) to configure nginx
3. setup node to serve nginx at port 80 and proxy chaosthebot.com requests to localhost:8080

This will allow us to serve different content from different servers without any issue.

i.e.
If you wanted to create a standalone restful api at chaosthebot.com/XYZapi but wanted to do it w/ node versus python, you could easily do so and nginx would handle the proxy bits.
