### PR TITLE
Don't allow people to add their own usernames to the codebase as such

### DIFF
--- a/github_api/comments.py
+++ b/github_api/comments.py
@@ -10,12 +10,21 @@ def get_reactions_for_comment(api, urn, comment_id):
     for reaction in reactions:
         yield reaction
 
-def leave_reject_comment(api, urn, pr):
+def leave_reject_comment_not_enough_votes(api, urn, pr):
     body = """
 :no_good: This PR did not meet the required vote threshold and will not be merged. \
 Closing.
 
 Open a new PR to restart voting.
+    """.strip()
+    return leave_comment(api, urn, pr, body)
+
+def leave_reject_comment_too_selfish(api, urn, pr):
+    body = """
+:no_good: This PR did not meet the required selflessness criteria and will not be merged. \
+Closing.
+
+Open a new PR *without adding your own username to the codebase* to restart voting.
     """.strip()
     return leave_comment(api, urn, pr, body)
 

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -1,6 +1,5 @@
 import arrow
 import re
-import requests
 import settings
 from . import misc
 from . import voting

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -1,4 +1,6 @@
 import arrow
+import re
+import requests
 import settings
 from . import misc
 from . import voting
@@ -24,7 +26,7 @@ def merge_pr(api, urn, pr, votes, total, threshold):
 
     pr_url = "https://github.com/{urn}/pull/{pr}".format(urn=urn, pr=pr_num)
 
-    title = "merging PR #{num}: {pr_title}".format(num=pr_num, pr_title=pr_title) 
+    title = "merging PR #{num}: {pr_title}".format(num=pr_num, pr_title=pr_title)
     desc = """
 {pr_url}: {pr_title}
 
@@ -104,6 +106,16 @@ def get_pr_comments(api, urn, pr_num):
     comments = api("get", path, params=params)
     for comment in comments:
         yield comment
+
+def owner_name_added_in_diff(api, urn, pr_num, owner_name):
+    """
+    Attempt to match the owner name in a diff as an addition.
+    Returns True if the owner_name is in the diff on an addition line.
+    """
+    path = 'http://github.com/{urn}/pull/{pr_num}.diff'
+    diff = api('get', path)
+    regex = '\+.+{username}'.format(username=owner_name)
+    return re.match(regex, diff)
 
 
 def get_ready_prs(api, urn, window):

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -114,7 +114,7 @@ def owner_name_added_in_diff(api, urn, pr_num, owner_name):
     """
     path = 'http://github.com/{urn}/pull/{pr_num}.diff'
     diff = api('get', path)
-    regex = '\+.+{username}'.format(username=owner_name)
+    regex = '\+.*{username}'.format(username=owner_name)
     return re.match(regex, diff, re.IGNORECASE)
 
 

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -115,7 +115,7 @@ def owner_name_added_in_diff(api, urn, pr_num, owner_name):
     path = 'http://github.com/{urn}/pull/{pr_num}.diff'
     diff = api('get', path)
     regex = '\+.+{username}'.format(username=owner_name)
-    return re.match(regex, diff)
+    return re.match(regex, diff, re.IGNORECASE)
 
 
 def get_ready_prs(api, urn, window):


### PR DESCRIPTION
Changelog:
- Added a function `owner_name_added_in_diff()` which will detect the PR owner's name in the PR diff as an addition.
- Reject PRs outright that exhibit selfishness.