### PR TITLE
Add missing doctype to website

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html lang="en">
   <head>
     <title>ChaosBot</title>


### PR DESCRIPTION
Also seems GitHub online editor added a new line at the end.