### PR TITLE
Voting threshold too high due to misleading github api

### DIFF
--- a/github_api/repos.py
+++ b/github_api/repos.py
@@ -1,6 +1,9 @@
 
 def get_num_watchers(api, urn):
+    """ returns the number of watchers for a repo """
     path = "/repos/{urn}".format(urn=urn)
     data = api("get", path)
-    return data["watchers_count"]
+    # this is the field for watchers.  do not be tricked by "watchers_count"
+    # which always matches "stargazers_count"
+    return data["subscribers_count"]
 

--- a/settings.py
+++ b/settings.py
@@ -41,7 +41,7 @@ MIN_VOTER_AGE = 1 * 30 * 24 * 60 * 60  # 1 month
 # for a pr to be merged, the vote total must have at least this fraction of the
 # number of watchers in order to pass.  this is to prevent early manipulation of
 # the project by requiring some basic consensus.
-MIN_VOTE_WATCHERS = 0.01
+MIN_VOTE_WATCHERS = 0.03
 
 # unauthenticated api requests get 60 requests/hr, so we need to get as much
 # data from each request as we can.  apparently 100 is the max number of pages


### PR DESCRIPTION
Could use a push to get this over the 14 vote threshold.  But then the threshold should be down to 3.54