### PR TITLE
Less harsh voting threshold

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -41,7 +41,7 @@ MIN_VOTER_AGE = 1 * 30 * 24 * 60 * 60  # 1 month
 # for a pr to be merged, the vote total must have at least this fraction of the
 # number of watchers in order to pass.  this is to prevent early manipulation of
 # the project by requiring some basic consensus.
-MIN_VOTE_WATCHERS = 0.01
+MIN_VOTE_WATCHERS = 0.005
 
 # unauthenticated api requests get 60 requests/hr, so we need to get as much
 # data from each request as we can.  apparently 100 is the max number of pages


### PR DESCRIPTION
A threshold of 1% of total git followers is currently 14.4. This change just halves the requirement. 

This is definitely a hotfix, a more intelligent algorithm should be put in place here.