### PR TITLE
Remove the mergeable tag

### DIFF
--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -143,7 +143,7 @@ def get_ready_prs(api, urn, window):
             # directly
             mergeable = get_is_mergeable(api, urn, pr_num)
             if mergeable is True:
-                label_pr(api, urn, pr_num, ["mergeable"])
+                label_pr(api, urn, pr_num, [])
                 yield pr
             elif mergeable is False:
                 label_pr(api, urn, pr_num, ["conflicts"])


### PR DESCRIPTION
Right now it's sorta useless and clogs things up. You can already tell if a PR is mergeable by checking if it doesn't have the conflicts tag.