### PR TITLE
Close stale PRs with merge conflicts

### DIFF
--- a/github_api/comments.py
+++ b/github_api/comments.py
@@ -29,6 +29,14 @@ See merge-commit {sha} for more details.
     """.strip().format(summary=votes_summary, sha=sha)
     return leave_comment(api, urn, pr, body)
 
+def leave_stale_comment(api, urn, pr, hours):
+    body = """
+:no_good: This PR has merge conflicts, and hasn't been touched in {hours} hours. Closing.
+
+Open a new PR with the merge conflicts fixed to restart voting.
+    """.strip().format(hours=hours)
+    return leave_comment(api, urn, pr, body)
+
 def leave_comment(api, urn, pr, body):
     path = "/repos/{urn}/issues/{pr}/comments".format(urn=urn, pr=pr)
     data = {"body": body}

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -2,6 +2,7 @@ import arrow
 import settings
 from . import misc
 from . import voting
+from . import comments
 from . import exceptions as exc
 
 
@@ -147,6 +148,11 @@ def get_ready_prs(api, urn, window):
                 yield pr
             elif mergeable is False:
                 label_pr(api, urn, pr_num, ["conflicts"])
+                last_update = max(arrow.get(pr["updated_at"]), updated)
+                update_delta = (now - last_update).total_seconds()
+                if update_delta >= 60 * 60 * settings.PR_STALE_HOURS:
+                    comments.leave_stale_comment(api, urn, pr["number"], round(update_delta / 60 / 60))
+                    close_pr(api, urn, pr)
             # mergeable can also be None, in which case we just skip it for now
 
 

--- a/settings.py
+++ b/settings.py
@@ -54,3 +54,7 @@ MEMOIZE_CACHE_DIRNAME = "api_cache"
 
 # used for calculating how long our voting window is
 TIMEZONE = "US/Pacific"
+
+# PRs that have merge conflicts and haven't been touched in this many hours
+# will be closed
+PR_STALE_HOURS = 24


### PR DESCRIPTION
This should take care of some of the PRs rotting at the bottom of the list.

I'm looking at `updated_at` so that comments will refresh the stale timer. That way, if people are deciding how to approach the merge conflicts, the PR won't close on them.