### PR TITLE
Post a rejected status for PRs with a negative vote total

### DIFF
--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -77,6 +77,8 @@ def poll_pull_requests():
                 gh.comments.leave_reject_comment(api, settings.URN, pr_num, votes, vote_total, threshold)
                 gh.prs.label_pr(api, settings.URN, pr_num, ["rejected"])
                 gh.prs.close_pr(api, settings.URN, pr)
+            elif vote_total < 0:
+                gh.prs.post_rejected_status(api, settings.URN, pr, voting_window, votes, vote_total, threshold)
             else:
                 gh.prs.post_pending_status(api, settings.URN, pr, voting_window, votes, vote_total, threshold)
 


### PR DESCRIPTION
I see a lot of PRs that have a pending status with 2 votes in favor 30 against. This will change that to rejected.

Why negative and not something like `-10`? First of all, negative represents a general negative view, which IMO fits the reject status. Second of all, a PR starts at +1 due to the author's implicit vote, so it'd take two downvotes before the first upvote to change the PR to negative. I think negative is a fair divider. We can change it in the future of course.