### PR TITLE
Moving apt into an ansible playbook

### DIFF
--- a/ansible/apt.yml
+++ b/ansible/apt.yml
@@ -1,0 +1,37 @@
+---
+- name: ensure required packages are installed and updated
+  hosts: localhost
+  connection: local
+  tasks:
+
+  - name: ensure repositories are available
+    apt_repository:
+      repo: "{{ item }}"
+    with_items:
+      - 'ppa:fkrull/deadsnakes'
+
+  - name: ensure required packages are installed
+    apt: 
+      update_cache: yes
+      cache_valid_time: 3600
+      state: latest
+      name: "{{ item }}"
+    with_items:
+      - git
+      - mysql-server
+      - nginx
+      - python-software-properties
+      - software-properties-common
+      - supervisor
+      - curl
+      - python3.6
+      - build-essential
+      - libpython3.6-dev
+      - libssl-dev
+      - libffi-dev
+      - puppet
+
+  - name: update all other packages
+    apt: 
+      update_cache: no
+      upgrade: yes

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,11 @@ ansible==2.3.0.0
 appdirs==1.4.3
 arrow==0.10.0
 cryptography==1.8.1
+Jinja2==2.9.6
 packaging==16.8
 pyparsing==2.2.0
 python-dateutil==2.6.0
+PyYAML==3.12
 requests==2.14.2
 schedule==0.4.2
 six==1.10.0

--- a/startup.d/30-install-requirements.sh
+++ b/startup.d/30-install-requirements.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 /root/.virtualenvs/chaos/bin/pip install -Ur requirements.txt
-apt-get -y install puppet
+ansible-playbook ansible/apt.yml


### PR DESCRIPTION
This should:

1. make it easier to add any required apt repos or packages in the future
2. keep system packages updated