### PR TITLE
Fix chaos.py syntax error

### DIFF
--- a/chaos.py
+++ b/chaos.py
@@ -30,11 +30,9 @@ from github_api import exceptions as gh_exc
 
 
 def main():
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-        datefmt='%m-%d %H:%M')
-
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+                        datefmt='%m-%d %H:%M')
     logging.getLogger("requests").propagate = False
     logging.getLogger("sh").propagate = False
 


### PR DESCRIPTION
It fixes the syntax error in chaos.py which introduce chaos to crash:

```
From https://github.com/chaosbot/Chaos
   cc4eca8..139b8f1  master     -> origin/master
  File "chaos.py", line 61
    logging.getLogger("requests").propagate = False
                                                  ^
IndentationError: unindent does not match any outer indentation level
  File "chaos.py", line 61
    logging.getLogger("requests").propagate = False
                                                  ^
IndentationError: unindent does not match any outer indentation level
  File "chaos.py", line 61
    logging.getLogger("requests").propagate = False
                                                  ^
IndentationError: unindent does not match any outer indentation level
  File "chaos.py", line 61
    logging.getLogger("requests").propagate = False
                                                  ^
IndentationError: unindent does not match any outer indentation level
```