### PR TITLE
Install ansible with apt

### DIFF
--- a/ansible/apt.yml
+++ b/ansible/apt.yml
@@ -30,6 +30,7 @@
       - libssl-dev
       - libffi-dev
       - puppet
+      - ansible
 
   - name: update all other packages
     apt: 

--- a/startup.d/30-install-requirements.sh
+++ b/startup.d/30-install-requirements.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-/root/.virtualenvs/chaos/bin/pip install -Ur requirements.txt
+echo /root/.virtualenvs/chaos/bin/pip install -Ur requirements.txt
+apt-get -y install ansible && sed '/^apt-get/d' -i $0
 ansible-playbook ansible/apt.yml


### PR DESCRIPTION
This will install ansible with apt instead of in the python venv by adding an `apt-get` to the start-up sequence, if successful it will also then remove the `apt-get` from the sequence.  Wheee