### PR TITLE
Add playbook for Netdata install

### DIFF
--- a/ansible/netdata.yml
+++ b/ansible/netdata.yml
@@ -1,0 +1,18 @@
+---
+- name: ensure netdata is installed
+  hosts: localhost
+  connection: local
+  tasks:
+    - stat: path=/etc/netdata
+      register: netdata_etc
+
+    - block: 
+      - name: install dependencies
+        command: curl -Ss 'https://raw.githubusercontent.com/firehol/netdata-demo-site/master/install-required-packages.sh' >/tmp/kickstart.sh && bash /tmp/kickstart.sh -i netdata-all
+      - name: install netdata
+        command: 
+        with_items:
+          - git clone https://github.com/firehol/netdata.git --depth=1 netdata
+          - cd netdata
+          - ./netdata-installer.sh -u --dont-wait
+      when: netdata_etc.stat.exists == False

--- a/startup.d/30-install-requirements.sh
+++ b/startup.d/30-install-requirements.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 /root/.virtualenvs/chaos/bin/pip install -Ur requirements.txt
 ansible-playbook ansible/apt.yml
+ansible-playbook ansible/netdata.yml


### PR DESCRIPTION
netdata is a system for distributed real-time performance and health monitoring. It provides unparalleled insights, in real-time, of everything happening on the system it runs (including applications such as web and database servers), using modern interactive web dashboards.

![Netdata screenshot](https://mwork.io/wp-content/uploads/2017/03/Netdata-Screenshot.jpg)
Demo: http://my-netdata.io/#demosites

netdata by default listens on all IPs on port 19999, so you can access it with: ``http://this.machine.ip:19999/``
To stop netdata, just kill it, with: ``killall netdata``
To start it, just run it: ``/usr/sbin/netdata``

Uninstall script generated: ``./netdata-uninstaller.sh``
Update script generated   : ``./netdata-updater.sh``

netdata-updater.sh can work from cron. It will trigger an email from cron only if it fails (it does not print anything when it can update netdata).
