### PR TITLE
Fix stale PR closing mechanism

### DIFF
--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -149,11 +149,9 @@ def get_ready_prs(api, urn, window):
                 yield pr
             elif mergeable is False:
                 label_pr(api, urn, pr_num, ["conflicts"])
-                last_update = max(arrow.get(pr["updated_at"]), updated)
-                update_delta = (now - last_update).total_seconds()
-                if update_delta >= 60 * 60 * settings.PR_STALE_HOURS:
+                if delta >= 60 * 60 * settings.PR_STALE_HOURS:
                     comments.leave_stale_comment(
-                        api, urn, pr["number"], round(update_delta / 60 / 60))
+                        api, urn, pr["number"], round(delta / 60 / 60))
                     close_pr(api, urn, pr)
             # mergeable can also be None, in which case we just skip it for now
 


### PR DESCRIPTION
See discussion in #218. I think applying the conflicts label was updating `updated_at`, so the condition would never be met. I've switched it to only looking at `pushed_at`. 24 hours should still be good enough for that.