### PR TITLE
Take it easy

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -73,4 +73,4 @@ with open("description.txt", "r") as h:
 
 # PRs that have merge conflicts and haven't been touched in this many hours
 # will be closed
-PR_STALE_HOURS = 48
+PR_STALE_HOURS = 36

--- a/settings.py
+++ b/settings.py
@@ -35,10 +35,10 @@ TEST = False
 PULL_REQUEST_POLLING_INTERVAL_SECONDS = 30
 
 # The default number of hours for how large the voting window is
-DEFAULT_VOTE_WINDOW = 2.0
+DEFAULT_VOTE_WINDOW = 3.0
 
 # The number of hours for how large the voting window is in the "after hours"
-AFTER_HOURS_VOTE_WINDOW = 3.0
+AFTER_HOURS_VOTE_WINDOW = 4.0
 
 # The hour (in the server time zone) when the after hours start
 AFTER_HOURS_START = 22
@@ -73,4 +73,4 @@ with open("description.txt", "r") as h:
 
 # PRs that have merge conflicts and haven't been touched in this many hours
 # will be closed
-PR_STALE_HOURS = 24
+PR_STALE_HOURS = 48


### PR DESCRIPTION
I think the voting window is too short, especially for people in different timezones than the US.

After the initial interest in chaosbot is slowly starting to fade, it makes sense to slow down the time limits in the voting process just a bit.