### PR TITLE
!!!SEIZE POWER HIJACK AMEND AUTOCRACY PR!!!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__
 github_pat.secret
 server/pubkey.txt
 server/voters.json
+api_cache/
+.idea/

--- a/github_api/__init__.py
+++ b/github_api/__init__.py
@@ -6,6 +6,17 @@ from requests.auth import HTTPBasicAuth
 import logging
 import settings
 
+from . import comments
+from . import exceptions
+from . import issues
+from . import misc
+from . import prs
+from . import repos
+from . import users
+from . import voting
+
+__all__ = ["comments", "exceptions", "issues", "misc", "prs", "repos", "users", "voting"]
+
 log = logging.getLogger("github_api")
 
 


### PR DESCRIPTION
- Implemented `__all__` in github_api module (fixes PyCharms 'Cannot find reference 'xxx' in xxx.py', see https://stackoverflow.com/questions/23248017/cannot-find-reference-xxx-in-init-py-python-pycharm).