### PR TITLE
Get `vagrant up` working again

### DIFF
--- a/dev/vagrant/Vagrantfile
+++ b/dev/vagrant/Vagrantfile
@@ -3,30 +3,23 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
-  
+
   # Network settings.
   config.vm.network "forwarded_port", guest: 80, host: 80, auto_correct: true
   config.vm.network "private_network", ip: "192.168.33.10"
 
   # Shared folder, just use /vagrant default (virtualbox style).
-  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+  config.vm.synced_folder "../..", "/vagrant", type: "virtualbox"
 
   # Ensure basic python requirements are initialized.
-  config.vm.provision "shell", inline: <<-SHELL2
+  config.vm.provision "shell", inline: <<-SCRIPT
+    apt-get install --assume-yes\
+        build-essential\
+        libssl-dev\
+        libffi-dev\
+        python-dev\
+        python3-pip
     cd /vagrant
-    apt-get install python3-pip -y
     pip3 install -r requirements.txt
-  SHELL2
-
-  # To run, type on host machine:
-  #
-  #   vagrant up
-  #   vagrant ssh
-  #
-  # When in SSH:
-  #
-  #   sudo su
-  #   cd /vagrant
-  #   python3 chaos.py
-
+  SCRIPT
 end


### PR DESCRIPTION
With these changes, the vagrant VM boots and provisions successfully for
me. I'm not sure it ever did for anyone before.
- Aside from pip, the packages are the native dependencies needed to get
  the following `pip3 install` to succeed.
- The change in `synced_folder` should have been when the Vagrant and
  Docker files were moved. This makes the entire repository available
  under `/vagrant` in the VM.
- Changed the heredoc delimiter to `SCRIPT` because WTH was it `SHELL2`?
- The whitespace changes are because my editor obeys the projects
  `.editorconfig`
- Removed the comment since it duplicates the README

Note that these changes *do not* get Chaos working in the VM.