### PR TITLE
MAKE @SMITTYVB LORD CHANCELLOR FOREVER!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ChaosBot
+# ChaosBoat
 
 [![Gitter chat](https://badges.gitter.im/chaosthebot/gitter.png)](https://gitter.im/chaosthebot/Lobby) [![ChaosBot](https://img.shields.io/badge/Chaos-Bot-green.svg)](http://chaosthebot.com/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ChaosBoat
+# ChaosBot
 
 [![Gitter chat](https://badges.gitter.im/chaosthebot/gitter.png)](https://gitter.im/chaosthebot/Lobby) [![ChaosBot](https://img.shields.io/badge/Chaos-Bot-green.svg)](http://chaosthebot.com/)
 

--- a/chaos.py
+++ b/chaos.py
@@ -32,7 +32,7 @@ def main():
     log = logging.getLogger("chaosbot")
 
     if exists("voters.json"):
-        log.info("Moving voters,json to server directory!")
+        log.info("Moving voters.json to server directory!")
         shutil.move("./voters.json", "./server/voters.json")
 
     api = gh.API(settings.GITHUB_USER, settings.GITHUB_SECRET)

--- a/chaos.py
+++ b/chaos.py
@@ -21,6 +21,7 @@ import github_api.prs
 import github_api.voting
 import github_api.repos
 import github_api.comments
+import github_api.issues
 
 # Has a sideeffect of creating private key if one doesn't exist already
 # Currently imported just for the sideeffect (not currently being used)
@@ -45,7 +46,7 @@ def main():
     log.info("checking if I crashed before...")
 
     # check if chaosbot is not on the tip of the master branch
-    check_for_prev_crash(api)
+    check_for_prev_crash(api, log)
 
     log.info("starting up and entering event loop")
 
@@ -91,10 +92,16 @@ def check_for_prev_crash(api, log):
 
             # Create a github issue for the problem
             body = """
-Oh no! I crashed on git sha {failed}. I rolled back to git sha {current} and am trying again!
+Oh no! I crashed!
 
-Error log: {dump}
-""".format(failed=failed,current=current,dump=dump)
+Failed on SHA {failed}
+Rolled back to SHA {current}
+
+Error log:
+```
+{dump}
+```
+""".format(failed=failed,current=current,dump=bytes.decode(dump))
 
 
             gh.issues.create_issue(api, settings.URN,

--- a/chaos.py
+++ b/chaos.py
@@ -66,6 +66,7 @@ def main():
         schedule.run_pending()
         time.sleep(1)
 
+
 def check_for_prev_crash(api, log):
     """
     Check if Chaosbot is attempting a recovery from a failure. If it is, then
@@ -91,6 +92,8 @@ def check_for_prev_crash(api, log):
             dump = subprocess.check_output(["tail", "-n", "200", settings.CHAOSBOT_STDERR_LOG])
 
             # Create a github issue for the problem
+            title = "Help! I crashed! --CB"
+            labels = ["crash report"]
             body = """
 Oh no! I crashed!
 
@@ -101,13 +104,9 @@ Error log:
 ```
 {dump}
 ```
-""".format(failed=failed,current=current,dump=bytes.decode(dump))
+""".format(failed=failed, current=current, dump=bytes.decode(dump))
 
-
-            gh.issues.create_issue(api, settings.URN,
-                    "Ah! I crashed!", # title
-                    body, # Body
-                    ["crash report"]) # labels
+            gh.issues.create_issue(api, settings.URN, title, body, labels)
 
             # remove the error file
             os.remove(settings.CHAOSBOT_FAILURE_FILE)

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -2,7 +2,7 @@
 
 function rollback() {
     # avoid commits from the same faulty PR
-    rb_commit=$(git log --author chaosbot --format=format:%H | tail -n +2 | head -n 1)
+    rb_commit=$(git log --author Chaos --format=format:%H | tail -n +2 | head -n 1)
     echo "Rollback to commit $rb_commit" >&2
     git reset --hard $rb_commit
 

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -19,8 +19,12 @@ time_elasped=`expr $(date +%s) - $start_time`
 if [ "$failed" -ne 0 ] && [ "$time_elasped" -le 60 ]; then
     echo "Crashed in less than 60 seconds!" >&2
     rollback
+else
+    if [ "$failed" -ne 0 ]; then
+        echo "Ah! We crashed! Not attempting rollback. Exiting :'(" >&2
+    else
+        # I don't think this can happen, but just for good measure...
+        echo "Uh, wat? We exited gracefully? Not attempting rollback. Exiting." >&2
+    fi
 fi
 
-if [ "$failed" -ne 0 ]; then
-    echo "Ah! We crashed! Not attempting rollback. Exiting :'(" >&2
-fi

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -25,7 +25,10 @@ time_elasped=`expr $(date +%s) - $start_time`
 
 if [ "$failed" -ne 0 ] && [ "$time_elasped" -le 60 ]; then
     echo "Crashed in less than 60 seconds!" >&2
-    rollback
+
+    # Only rollback if this is the production server...
+    ((git remote -v | grep origin | grep -q chaosbot/Chaos) && rollback) || \
+        (echo "DEV ENV -- NOT ROLLING BACK" >&2)
 else
     if [ "$failed" -ne 0 ]; then
         echo "Ah! We crashed! Not attempting rollback. Exiting :'(" >&2

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -8,6 +8,7 @@ function rollback() {
 
     # make supervisord re-read its config because we might have changed that
     supervisorctl reread
+    supervisorctl restart chaos
 }
 
 # time the chaos server... if it crashes in 60s, then attempt a rollback

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -20,3 +20,7 @@ if [ "$failed" -ne 0 ] && [ "$time_elasped" -le 60 ]; then
     echo "Crashed in less than 60 seconds!" >&2
     rollback
 fi
+
+if [ "$failed" -ne 0 ]; then
+    echo "Ah! We crashed! Not attempting rollback. Exiting :'(" >&2
+fi

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -8,7 +8,7 @@ function rollback() {
 
     # make supervisord re-read its config because we might have changed that
     supervisorctl reread
-    supervisorctl restart chaos
+    supervisorctl update
 }
 
 # time the chaos server... if it crashes in 60s, then attempt a rollback

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -2,9 +2,15 @@
 
 function rollback() {
     # can just go back to the previous commit because chaosbot squashes merges
+    current_commit=$(git rev-parse HEAD)
     rb_commit=$(git rev-parse HEAD^)
     echo "Rollback to commit $rb_commit" >&2
     git reset --hard $rb_commit
+
+    # Create a file to denote that chaosbot failed...
+    # The name of this file is also used in the settings.py, so change it
+    # in both places if you are going to.
+    echo "$current_commit $rb_commit" > /tmp/chaosbot_failed
 
     # make supervisord re-read its config because we might have changed that
     supervisorctl reread

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -5,11 +5,14 @@ function rollback() {
     rb_commit=$(git log --author chaosbot --format=format:%H | tail -n +2 | head -n 1)
     echo "Rollback to commit $rb_commit" >&2
     git reset --hard $rb_commit
+
+    # make supervisord re-read its config because we might have changed that
+    supervisorctl reread
 }
 
 # time the chaos server... if it crashes in 60s, then attempt a rollback
 start_time=`date +%s`
-/root/.virtualenvs/chaos/bin/python chaos.py 
+/root/.virtualenvs/chaos/bin/python chaos.py
 failed=$?
 time_elasped=`expr $(date +%s) - $start_time`
 

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -13,7 +13,7 @@ start_time=`date +%s`
 failed=$?
 time_elasped=`expr $(date +%s) - $start_time`
 
-if [ "$failed" -eq 0 ] && [ "$time_elasped" -le 60 ]; then
+if [ "$failed" -ne 0 ] && [ "$time_elasped" -le 60 ]; then
     echo "Crashed in less than 60 seconds!" >&2
     rollback
 fi

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -2,7 +2,7 @@
 
 function rollback() {
     git checkout master
-    git checkout ^HEAD
+    git checkout HEAD^
 }
 
 /root/.virtualenvs/chaos/bin/python chaos.py || rollback

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 function rollback() {
-    # avoid commits from the same faulty PR
-    rb_commit=$(git log --author Chaos --format=format:%H | tail -n +2 | head -n 1)
+    # can just go back to the previous commit because chaosbot squashes merges
+    rb_commit=$(git rev-parse HEAD^)
     echo "Rollback to commit $rb_commit" >&2
     git reset --hard $rb_commit
 

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function rollback() {
+    git checkout master
+    git checkout ^HEAD
+}
+
+/root/.virtualenvs/chaos/bin/python chaos.py || rollback

--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
 function rollback() {
-    git checkout master
-    git checkout HEAD^
+    # avoid commits from the same faulty PR
+    rb_commit=$(git log --author chaosbot --format=format:%H | tail -n +2 | head -n 1)
+    echo "Rollback to commit $rb_commit" >&2
+    git reset --hard $rb_commit
 }
 
-/root/.virtualenvs/chaos/bin/python chaos.py || rollback
+# time the chaos server... if it crashes in 60s, then attempt a rollback
+start_time=`date +%s`
+/root/.virtualenvs/chaos/bin/python chaos.py 
+failed=$?
+time_elasped=`expr $(date +%s) - $start_time`
+
+if [ "$failed" -eq 0 ] && [ "$time_elasped" -le 60 ]; then
+    echo "Crashed in less than 60 seconds!" >&2
+    rollback
+fi

--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -128,7 +128,7 @@ def poll_pull_requests():
         startup_path = join(THIS_DIR, "..", "startup.sh")
 
         # before we exec, we need to flush i/o buffers so we don't lose logs or voters
-        sys.stdout.flush() 
+        sys.stdout.flush()
         sys.stderr.flush()
 
         os.execl(startup_path, startup_path)

--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -2,6 +2,7 @@ import arrow
 import logging
 import json
 import os
+import sys
 from os.path import join, abspath, dirname
 
 import settings
@@ -57,7 +58,7 @@ def poll_pull_requests():
                     sha = gh.prs.merge_pr(api, settings.URN, pr, votes, vote_total,
                                           threshold)
                 # some error, like suddenly there's a merge conflict, or some
-                # new commits were introduced between findint this ready pr and
+                # new commits were introduced between finding this ready pr and
                 # merging it
                 except gh.exceptions.CouldntMerge:
                     __log.info("couldn't merge PR %d for some reason, skipping",
@@ -118,10 +119,18 @@ def poll_pull_requests():
                     old_votes[user] = 1
             json.dump(old_votes, fp)
 
+            # flush all buffers because we might restart, which could cause a crash
+            os.fsync(fp)
+
     # we approved a PR, restart
     if needs_update:
         __log.info("updating code and requirements and restarting self")
         startup_path = join(THIS_DIR, "..", "startup.sh")
+
+        # before we exec, we need to flush i/o buffers so we don't lose logs or voters
+        sys.stdout.flush() 
+        sys.stderr.flush()
+
         os.execl(startup_path, startup_path)
 
     __log.info("Waiting %d seconds until next scheduled PR polling event",

--- a/dev/vagrant/Vagrantfile
+++ b/dev/vagrant/Vagrantfile
@@ -14,6 +14,7 @@ Vagrant.configure("2") do |config|
   # Ensure basic python requirements are initialized.
   config.vm.provision "shell", inline: <<-SCRIPT
     apt-get install --assume-yes\
+	git\
         build-essential\
         libssl-dev\
         libffi-dev\

--- a/dev/vagrant/Vagrantfile
+++ b/dev/vagrant/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
   # Ensure basic python requirements are initialized.
   config.vm.provision "shell", inline: <<-SCRIPT
     apt-get install --assume-yes\
-	git\
+        git\
         build-essential\
         libssl-dev\
         libffi-dev\

--- a/etc/chaos_supervisor.conf
+++ b/etc/chaos_supervisor.conf
@@ -1,5 +1,5 @@
 [program:chaos]
-command=chaos_wrapper.sh
+command=bash chaos_wrapper.sh
 directory=/root/workspace/Chaos
 user=root
 

--- a/etc/chaos_supervisor.conf
+++ b/etc/chaos_supervisor.conf
@@ -1,5 +1,5 @@
 [program:chaos]
-command=/root/.virtualenvs/chaos/bin/python chaos.py
+command=chaos_wrapper.sh
 directory=/root/workspace/Chaos
 user=root
 
@@ -10,3 +10,9 @@ stdout_logfile_backups=10
 stderr_logfile=/var/log/supervisor/chaos-stderr.log
 stderr_logfile_maxbytes=1MB
 stderr_logfile_backups=10
+
+# need to be alive for at least 60s
+startsecs=60
+
+# retry startup up to 10 times
+startretries=10

--- a/github_api/issues.py
+++ b/github_api/issues.py
@@ -41,3 +41,13 @@ def voting_window_remaining_seconds(api, urn, comment, window):
 
 def is_issue_comment_in_voting_window(api, urn, comment, window):
     return voting_window_remaining_seconds(api, urn, comment, window) <= 0
+
+def create_issue(api, urn, title, body, labels):
+    path = "/repos/{urn}/issues".format(urn=urn)
+    data = {
+            "title": title,
+            "body": body,
+            "labels": labels,
+            }
+    resp = api("post", path, json=data)
+    return resp

--- a/github_api/issues.py
+++ b/github_api/issues.py
@@ -42,6 +42,7 @@ def voting_window_remaining_seconds(api, urn, comment, window):
 def is_issue_comment_in_voting_window(api, urn, comment, window):
     return voting_window_remaining_seconds(api, urn, comment, window) <= 0
 
+
 def create_issue(api, urn, title, body, labels):
     path = "/repos/{urn}/issues".format(urn=urn)
     data = {

--- a/settings.py
+++ b/settings.py
@@ -82,3 +82,11 @@ with open("description.txt", "r") as h:
 PR_STALE_HOURS = 36
 
 API_COOLDOWN_RESET_PADDING = 30
+
+# The name of the file created upon failures -- also found in chaos_wrapper.py
+# If you are going to change it, change it there too.
+CHAOSBOT_FAILURE_FILE = "/tmp/chaosbot_failed"
+
+# The location of error log -- also found in the supervisor conf.
+# If you are going to change it, change it there too.
+CHAOSBOT_STDERR_LOG = "/var/log/supervisor/chaos-stderr.log"


### PR DESCRIPTION
- If chaosbot crashes within the first 60s of starting, it is restarted by supervisord up to 10 times before supervisord finally gives up. This gives chaosbot a chance to go through at least one poll/merge cycle.

- Every time chaosbot crashes it reverts to an older commit in the git history in the hope that this resolves the issue. To prevent attackers from hiding malicious code in their PRs and getting chaosbot to rollback to them, we only rollback to commits by chaosbot itself (i.e. merges).

- When chaosbot crashes, it posts an issue on github

- Meanwhile, if there is a pull request for it to pull and merge, it does so after checking out master, so chaosbot will never get stuck in the past.

- Rollbacks are disabled unless the git remote called `origin` is `chaosbot/Chaos`

- Throw in a few typo and minor bug fixes, too...

EDIT: updated rollback stuff
EDIT: updated again with recent developements
EDIT: To be clear, this PR has nothing to do with changing the voting system... The title is mostly just to attract attention :laughing: 