### PR TITLE
squash PRs instead of merge commits

### DIFF
--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -48,11 +48,17 @@ Description:
     data = {
         "commit_title": title,
         "commit_message": desc,
-        "merge_method": "merge",
 
         # if some clever person attempts to submit more commits while we're
         # aggregating votes, this sha check will fail and no merge will occur
         "sha": pr["head"]["sha"],
+
+        # default is "merge"
+        # i think we want to do a squash so its easier to auto-revert entire
+        # PRs, instead of detecting merge commits, then picking the right parent
+        # for a revert.  this way—with squash—every commit aside from hotfixes
+        # will be entire PRs
+        "merge_method": "squash",
     }
     try:
         resp = api("PUT", path, json=data)


### PR DESCRIPTION
```
        # i think we want to do a squash so its easier to auto-revert entire
        # PRs, instead of detecting merge commits, then picking the right parent
        # for a revert.  this way—with squash—every commit aside from hotfixes
        # will be entire PRs
```

### Merge commit (old way):
![merge commit](https://cloud.githubusercontent.com/assets/143418/14124216/4533f320-f5b9-11e5-9e38-90266106d171.png)

### Squash commit (proposed way)
![squash commit](https://cloud.githubusercontent.com/assets/143418/14123752/eef5aef6-f5b6-11e5-81f5-466b3a4d3a3a.png)