### PR TITLE
Fix: Change Travis-CI detection check

### DIFF
--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -149,7 +149,8 @@ def has_build_passed(api, statuses_url):
     if statuses:
         for status in statuses:
             # Check the state and context of the commit status
-            # the state can be a success for Chaosbot statuses, so we double-check context for a Travis CI context
+            # the state can be a success for Chaosbot statuses,
+            # so we double-check context for a Travis CI context
             if (status["state"] == "success") and \
                (status["context"] == "continuous-integration/travis-ci/pr"):
                 return True

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -9,6 +9,8 @@ from . import exceptions as exc
 from . import misc
 from . import voting
 
+TRAVIS_CI_CONTEXT = "continuous-integration/travis-ci"
+
 
 def merge_pr(api, urn, pr, votes, total, threshold):
     """ merge a pull request, if possible, and use a nice detailed merge commit
@@ -152,7 +154,7 @@ def has_build_passed(api, statuses_url):
             # the state can be a success for Chaosbot statuses,
             # so we double-check context for a Travis CI context
             if (status["state"] == "success") and \
-               (status["context"] == "continuous-integration/travis-ci/pr"):
+               (status["context"].startswith(TRAVIS_CI_CONTEXT)):
                 return True
     return False
 

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -138,7 +138,7 @@ def has_build_passed(api, statuses_url):
     """
         Check if a Pull request has passed Travis CI builds
     :param api: github api instance
-    :param statuses_url: full url to the github commit statuses.
+    :param statuses_url: full url to the github commit status.
            Given in pr["statuses_url"]
     :return: true if the commit passed travis build, false if failed or still pending
     """
@@ -148,10 +148,10 @@ def has_build_passed(api, statuses_url):
 
     if statuses:
         for status in statuses:
-            # check state is success and description of status
-            # the state can be success for Chaosbot statuses, so we double-check if it a Travis CI
+            # Check the state and context of the commit status
+            # the state can be a success for Chaosbot statuses, so we double-check context for a Travis CI context
             if (status["state"] == "success") and \
-               (status["description"] == "The Travis CI build passed"):
+               (status["context"] == "continuous-integration/travis-ci/pr"):
                 return True
     return False
 

--- a/tests/github_api/prs_test.py
+++ b/tests/github_api/prs_test.py
@@ -19,31 +19,42 @@ class TestPRMethods(unittest.TestCase):
 
         self.assertTrue(prs.has_build_passed(api, url))
 
-    def test_statuses_returns_failed_travis_build(self):
-        statuses = [{"state": "error",
-                    "context": "continuous-integration/travis-ci/pr"}]
+    def test_statuses_returns_failed_travis_build_in_wrong_context(self):
+        test_data = [[{"state": "pending",
+                       "context": "some_other_context"}],
+                     [{"state": "success",
+                       "context": "some_other_context"}],
+                     [{"state": "error",
+                       "context": "some_other_other_context"}],
+                     ]
         pr = "/repos/test/blah"
 
-        class Mocked(API):
-            def __call__(m, method, path, **kwargs):
-                self.assertEqual(pr, path)
-                return statuses
+        for statuses in test_data:
+            class Mocked(API):
+                def __call__(m, method, path, **kwargs):
+                    self.assertEqual(pr, path)
+                    return statuses
 
-        api = Mocked("user", "pat")
-        url = "{}{}".format(api.BASE_URL, pr)
+            api = Mocked("user", "pat")
+            url = "{}{}".format(api.BASE_URL, pr)
 
-        self.assertFalse(prs.has_build_passed(api, url))
+            self.assertFalse(prs.has_build_passed(api, url))
 
-        statuses = [{"state": "pending",
-                    "context": "some_other_context"}]
+    def test_statuses_returns_failed_travis_build_in_correct_context(self):
+        test_data = [[{"state": "error",
+                     "context": "continuous-integration/travis-ci/pr"}],
+                     [{"state": "pending",
+                       "context": "continuous-integration/travis-ci/pr"}],
+                     ]
         pr = "/repos/test/blah"
 
-        class Mocked(API):
-            def __call__(m, method, path, **kwargs):
-                self.assertEqual(pr, path)
-                return statuses
+        for statuses in test_data:
+            class Mocked(API):
+                def __call__(m, method, path, **kwargs):
+                    self.assertEqual(pr, path)
+                    return statuses
 
-        api = Mocked("user", "pat")
-        url = "{}{}".format(api.BASE_URL, pr)
+            api = Mocked("user", "pat")
+            url = "{}{}".format(api.BASE_URL, pr)
 
-        self.assertFalse(prs.has_build_passed(api, url))
+            self.assertFalse(prs.has_build_passed(api, url))

--- a/tests/github_api/prs_test.py
+++ b/tests/github_api/prs_test.py
@@ -5,19 +5,25 @@ from github_api import prs, API
 
 class TestPRMethods(unittest.TestCase):
     def test_statuses_returns_passed_travis_build(self):
-        statuses = [{"state": "success",
-                    "context": "continuous-integration/travis-ci/pr"}]
+        test_data = [[{"state": "success",
+                     "context": "continuous-integration/travis-ci/pr"}],
+                     [{"state": "success",
+                       "context": "continuous-integration/travis-ci/pr"},
+                      {"state": "failure",
+                       "context": "chaosbot"}],
+                     ]
         pr = "/repos/test/blah"
 
-        class Mocked(API):
-            def __call__(m, method, path, **kwargs):
-                self.assertEqual(pr, path)
-                return statuses
+        for statuses in test_data:
+            class Mocked(API):
+                def __call__(m, method, path, **kwargs):
+                    self.assertEqual(pr, path)
+                    return statuses
 
-        api = Mocked("user", "pat")
-        url = "{}{}".format(api.BASE_URL, pr)
+            api = Mocked("user", "pat")
+            url = "{}{}".format(api.BASE_URL, pr)
 
-        self.assertTrue(prs.has_build_passed(api, url))
+            self.assertTrue(prs.has_build_passed(api, url))
 
     def test_statuses_returns_failed_travis_build_in_wrong_context(self):
         test_data = [[{"state": "pending",

--- a/tests/github_api/prs_test.py
+++ b/tests/github_api/prs_test.py
@@ -6,7 +6,7 @@ from github_api import prs, API
 class TestPRMethods(unittest.TestCase):
     def test_statuses_returns_passed_travis_build(self):
         statuses = [{"state": "success",
-                    "description": "The Travis CI build passed"}]
+                    "context": "continuous-integration/travis-ci/pr"}]
         pr = "/repos/test/blah"
 
         class Mocked(API):
@@ -21,7 +21,7 @@ class TestPRMethods(unittest.TestCase):
 
     def test_statuses_returns_failed_travis_build(self):
         statuses = [{"state": "error",
-                    "description": "The Travis CI build failed"}]
+                    "context": "continuous-integration/travis-ci/pr"}]
         pr = "/repos/test/blah"
 
         class Mocked(API):
@@ -35,7 +35,7 @@ class TestPRMethods(unittest.TestCase):
         self.assertFalse(prs.has_build_passed(api, url))
 
         statuses = [{"state": "pending",
-                    "description": "The Travis CI build is in progress"}]
+                    "context": "some_other_context"}]
         pr = "/repos/test/blah"
 
         class Mocked(API):


### PR DESCRIPTION
This new method is less error prone if Travis ever changes the success string. Instead, we check to see if the context of the status is Travis PR related.

As [reviewed](https://github.com/chaosbot/Chaos/pull/331#discussion-diff-118841694R154) by @jeroeness and @phil-r 