### PR TITLE
Lower threshold per watchers from 0.05 to 0.04

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -57,7 +57,7 @@ MIN_VOTER_AGE = 1 * 30 * 24 * 60 * 60  # 1 month
 # for a pr to be merged, the vote total must have at least this fraction of the
 # number of watchers in order to pass.  this is to prevent early manipulation of
 # the project by requiring some basic consensus.
-MIN_VOTE_WATCHERS = 0.05
+MIN_VOTE_WATCHERS = 0.04
 
 # unauthenticated api requests get 60 requests/hr, so we need to get as much
 # data from each request as we can.  apparently 100 is the max number of pages


### PR DESCRIPTION
Right now it's at `6.5`, this would lower it to `5.2`.