### PR TITLE
Position prefix + monospace font on voters.html

### DIFF
--- a/server/voters.html
+++ b/server/voters.html
@@ -44,3 +44,14 @@
         }
     }
 </script>
+
+<style>
+    body {
+        font-family: monospace;
+        counter-reset: voter;
+    }
+    table > tbody > tr > td:first-child::before {
+        counter-increment: voter;
+        content: counter(voter) ". ";
+    }
+</style>


### PR DESCRIPTION
Adds a prefix to entries in the voters table showing how far down they are. Also use a monospace font - which is a start on #319 point 2.