### PR TITLE
Add CSS radial backgrounds

### DIFF
--- a/server/static/css/main.css
+++ b/server/static/css/main.css
@@ -99,6 +99,9 @@ body.transform {
 
 /* BACKGROUND */
 #bg {
+    background: radial-gradient(at 30% 10%, rgb(243, 72, 45), transparent 90vw),
+        radial-gradient(at 10% 10%, rgb(243, 72, 45), transparent 100vw),
+        radial-gradient(at 10% 50%, rgb(243, 72, 45), transparent 50vw);
     position: fixed;
     top: 0;
     left: 0;

--- a/server/static/js/background.js
+++ b/server/static/js/background.js
@@ -87,39 +87,6 @@ if (background.getContext){
 		// fctx2.stroke();
 	};
 	
-	var drawBack = function(){
-		bctx.clearRect(0, 0, wWidth, wHeight);
-		
-		var gradient = [];
-		gradient[0] = bctx.createRadialGradient(wWidth*0.3, wHeight*0.1, 0, wWidth*0.3, wHeight*0.1, wWidth*0.9);
-		gradient[0].addColorStop(0, 'rgb(243, 72, 45)');
-		gradient[0].addColorStop(1, 'transparent');
-		
-		bctx.translate(wWidth, 0);
-		bctx.scale(-1,1);
-		bctx.beginPath();
-		bctx.fillStyle = gradient[0];
-		bctx.fillRect(0, 0, wWidth, wHeight);
-		
-		gradient[1] = bctx.createRadialGradient(wWidth*0.1, wHeight*0.1, 0, wWidth*0.3, wHeight*0.1, wWidth);
-		gradient[1].addColorStop(0, 'rgb(243, 72, 45)');
-		gradient[1].addColorStop(0.8, 'transparent');
-		
-		bctx.translate(wWidth, 0);
-		bctx.scale(-1,1);
-		bctx.beginPath();
-		bctx.fillStyle = gradient[1];
-		bctx.fillRect(0, 0, wWidth, wHeight);
-		
-		gradient[2] = bctx.createRadialGradient(wWidth*0.1, wHeight*0.5, 0, wWidth*0.1, wHeight*0.5, wWidth*0.5);
-		gradient[2].addColorStop(0, 'rgb(243, 72, 45)');
-		gradient[2].addColorStop(1, 'transparent');
-		
-		bctx.beginPath();
-		bctx.fillStyle = gradient[2];
-		bctx.fillRect(0, 0, wWidth, wHeight);
-	};
-	
 	var animate = function(){
 		var sin = M.sin(degree),
 		cos = M.cos(degree);
@@ -225,7 +192,6 @@ if (background.getContext){
 		
 		cancelAnimationFrame(timer);
 		timer = requestAnimationFrame(animate);
-		drawBack();
 	};
 	
 	setCanvasHeight();


### PR DESCRIPTION
These should scale a bit nicer than the canvas gradient.

# Screenshots
Taken with Chrome 58.0.3029.110 64-bit, Windows 10 (in case anything looks off for anyone else).

## Before
![chaosthebot com-test1](https://cloud.githubusercontent.com/assets/1917406/26554504/62bf5ec4-4488-11e7-8d1d-04973f44d523.png)

## After
![chaosthebot com-test2](https://cloud.githubusercontent.com/assets/1917406/26554513/6b909c20-4488-11e7-9684-8ec8ee2e1ceb.png)

(Note: the particles are stretched due to how I took screenshots in Chrome - they aren't normally stretched.)

If anyone has any suggestions on how to make them look more like the old ones, please let me know!