### PR TITLE
/vote close on stale issues

### DIFF
--- a/chaos.py
+++ b/chaos.py
@@ -56,7 +56,7 @@ def main():
     subprocess.Popen([sys.executable, "server.py"], cwd=server_dir)
 
     # Schedule all cron jobs to be run
-    cron.schedule_jobs()
+    cron.schedule_jobs(api)
 
     log.info("Setting description to {desc}".format(desc=settings.REPO_DESCRIPTION))
     github_api.repos.set_desc(api, settings.URN, settings.REPO_DESCRIPTION)

--- a/cron/__init__.py
+++ b/cron/__init__.py
@@ -3,6 +3,7 @@ import settings
 
 from .poll_pull_requests import poll_pull_requests as poll_pull_requests
 from .poll_read_issue_comments import poll_read_issue_comments
+from .poll_issue_close_stale import poll_issue_close_stale
 
 
 def schedule_jobs():
@@ -10,3 +11,5 @@ def schedule_jobs():
         poll_pull_requests)
     schedule.every(settings.ISSUE_COMMENT_POLLING_INTERVAL_SECONDS).seconds.do(
         poll_read_issue_comments)
+    schedule.every(settings.ISSUE_CLOSE_STALE_INTERVAL_SECONDS).seconds.do(
+        poll_issue_close_stale)

--- a/cron/__init__.py
+++ b/cron/__init__.py
@@ -13,3 +13,7 @@ def schedule_jobs(api):
             lambda: poll_read_issue_comments(api))
     schedule.every(settings.ISSUE_CLOSE_STALE_INTERVAL_SECONDS).seconds.do(
             lambda: poll_issue_close_stale(api))
+
+    # Call manually the first time, so that we are guaranteed this will run
+    # at least once in the interval...
+    poll_issue_close_stale(api)

--- a/cron/__init__.py
+++ b/cron/__init__.py
@@ -6,10 +6,10 @@ from .poll_read_issue_comments import poll_read_issue_comments
 from .poll_issue_close_stale import poll_issue_close_stale
 
 
-def schedule_jobs():
+def schedule_jobs(api):
     schedule.every(settings.PULL_REQUEST_POLLING_INTERVAL_SECONDS).seconds.do(
-        poll_pull_requests)
+            lambda: poll_pull_requests(api))
     schedule.every(settings.ISSUE_COMMENT_POLLING_INTERVAL_SECONDS).seconds.do(
-        poll_read_issue_comments)
+            lambda: poll_read_issue_comments(api))
     schedule.every(settings.ISSUE_CLOSE_STALE_INTERVAL_SECONDS).seconds.do(
-        poll_issue_close_stale)
+            lambda: poll_issue_close_stale(api))

--- a/cron/poll_issue_close_stale.py
+++ b/cron/poll_issue_close_stale.py
@@ -24,19 +24,22 @@ def poll_issue_close_stale():
     __log.info("There are currently %d open issues" % len(issues))
 
     for issue in issues:
+        number = issue["number"]
         last_updated = arrow.get(issue["updated_at"])
 
         now = arrow.utcnow()
         delta = (now - last_updated).total_seconds()
 
+        __log.info("Issue %d has not been updated in %d seconds" % (number, delta))
+
         if delta > settings.ISSUE_STALE_THRESHOLD:
-            __log.info("Vote close issue %d" % issue["id"])
+            __log.info("/vote close issue %d" % number)
 
             # leave an explanatory comment
             body = "This issue hasn't been active for a while." + \
                     "To keep it open, react with :-1: on the `vote close` post."
-            gh.comments.leave_comment(api, settings.URN, issue["id"], body)
+            gh.comments.leave_comment(api, settings.URN, number, body)
 
             # then vote to close
             body = "/vote close"
-            gh.comments.leave_comment(api, settings.URN, issue["id"], body)
+            gh.comments.leave_comment(api, settings.URN, number, body)

--- a/cron/poll_issue_close_stale.py
+++ b/cron/poll_issue_close_stale.py
@@ -1,7 +1,5 @@
 import arrow
 import logging
-import os
-from os.path import join, abspath, dirname
 
 import settings
 import github_api as gh
@@ -29,13 +27,14 @@ def poll_issue_close_stale():
         last_updated = arrow.get(issue["updated_at"])
 
         now = arrow.utcnow()
-        delta = (now - updated).total_seconds()
+        delta = (now - last_updated).total_seconds()
 
         if delta > settings.ISSUE_STALE_THRESHOLD:
             __log.info("Vote close issue %d" % issue["id"])
 
             # leave an explanatory comment
-            body = "This issue hasn't been active for a while. To keep it open, react with :-1: on the `vote close` post."
+            body = "This issue hasn't been active for a while." + \
+                    "To keep it open, react with :-1: on the `vote close` post."
             gh.comments.leave_comment(api, settings.URN, issue["id"], body)
 
             # then vote to close

--- a/cron/poll_issue_close_stale.py
+++ b/cron/poll_issue_close_stale.py
@@ -1,0 +1,51 @@
+import arrow
+import logging
+import os
+from os.path import join, abspath, dirname
+
+import settings
+import github_api as gh
+
+THIS_DIR = dirname(abspath(__file__))
+# Hopefully this isn't overwritten on pulls
+LAST_POLL_FILE = join(THIS_DIR, '..', "server/last_poll.txt")
+if not os.path.exists(LAST_POLL_FILE):
+    with open(LAST_POLL_FILE, 'w') as f:
+        dummy_data = {"comment_ids_ran": []}
+        json.dump(dummy_data, f)
+
+__log = logging.getLogger("poll_close_stale")
+
+
+def poll_issue_close_stale():
+    """
+    Looks through all open issues. For any open issue, if the issue is
+    too old and has not been recently commented on, chaosbot issues a
+    /vote close...
+    """
+
+    __log.info("Checking for stale issues...")
+
+    api = gh.API(settings.GITHUB_USER, settings.GITHUB_SECRET)
+
+    # Get all issues
+    issues = gh.issues.get_open_issues(api, settings.URN)
+
+    __log.info("There are currently %d open issues" % len(issues))
+
+    for issue in issues:
+        last_updated = arrow.get(issue["updated_at"])
+
+        now = arrow.utcnow()
+        delta = (now - updated).total_seconds()
+
+        if delta > settings.ISSUE_STALE_THRESHOLD:
+            __log.info("Vote close issue %d" % issue["id"])
+
+            # leave an explanatory comment
+            body = "This issue hasn't been active for a while. To keep it open, react with :-1: on the `vote close` post."
+            gh.comments.leave_comment(api, settings.URN, issue["id"], body)
+
+            # then vote to close
+            body = "/vote close"
+            gh.comments.leave_comment(api, settings.URN, issue["id"], body)

--- a/cron/poll_issue_close_stale.py
+++ b/cron/poll_issue_close_stale.py
@@ -6,14 +6,6 @@ from os.path import join, abspath, dirname
 import settings
 import github_api as gh
 
-THIS_DIR = dirname(abspath(__file__))
-# Hopefully this isn't overwritten on pulls
-LAST_POLL_FILE = join(THIS_DIR, '..', "server/last_poll.txt")
-if not os.path.exists(LAST_POLL_FILE):
-    with open(LAST_POLL_FILE, 'w') as f:
-        dummy_data = {"comment_ids_ran": []}
-        json.dump(dummy_data, f)
-
 __log = logging.getLogger("poll_close_stale")
 
 

--- a/cron/poll_issue_close_stale.py
+++ b/cron/poll_issue_close_stale.py
@@ -7,7 +7,7 @@ import github_api as gh
 __log = logging.getLogger("poll_close_stale")
 
 
-def poll_issue_close_stale():
+def poll_issue_close_stale(api):
     """
     Looks through all open issues. For any open issue, if the issue is
     too old and has not been recently commented on, chaosbot issues a
@@ -15,8 +15,6 @@ def poll_issue_close_stale():
     """
 
     __log.info("Checking for stale issues...")
-
-    api = gh.API(settings.GITHUB_USER, settings.GITHUB_SECRET)
 
     # Get all issues
     issues = gh.issues.get_open_issues(api, settings.URN)

--- a/cron/poll_issue_close_stale.py
+++ b/cron/poll_issue_close_stale.py
@@ -37,7 +37,7 @@ def poll_issue_close_stale():
 
             # leave an explanatory comment
             body = "This issue hasn't been active for a while." + \
-                    "To keep it open, react with :-1: on the `vote close` post."
+                "To keep it open, react with :-1: on the `vote close` post."
             gh.comments.leave_comment(api, settings.URN, number, body)
 
             # then vote to close

--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -13,10 +13,8 @@ THIS_DIR = dirname(abspath(__file__))
 __log = logging.getLogger("chaosbot")
 
 
-def poll_pull_requests():
+def poll_pull_requests(api):
     __log.info("looking for PRs")
-
-    api = gh.API(settings.GITHUB_USER, settings.GITHUB_SECRET)
 
     # get voting window
     now = arrow.utcnow()

--- a/cron/poll_read_issue_comments.py
+++ b/cron/poll_read_issue_comments.py
@@ -23,7 +23,7 @@ if not os.path.exists(SAVED_COMMANDS_FILE):
         dummy_data = {"comment_ids_ran": []}
         json.dump(dummy_data, f)
 
-__log = logging.getLogger("chaosbot")
+__log = logging.getLogger("poll_issue_commands")
 
 '''
 Command Syntax

--- a/cron/poll_read_issue_comments.py
+++ b/cron/poll_read_issue_comments.py
@@ -132,10 +132,8 @@ def handle_comment(api, issue_comment):
                                     global_comment_id, votes)
 
 
-def poll_read_issue_comments():
+def poll_read_issue_comments(api):
     __log.info("looking for issue comments")
-
-    api = gh.API(settings.GITHUB_USER, settings.GITHUB_SECRET)
 
     issue_comments = gh.comments.get_all_issue_comments(api, settings.URN)
 

--- a/github_api/issues.py
+++ b/github_api/issues.py
@@ -21,7 +21,7 @@ def get_open_issues(api, urn):
     data = {"state": "open"}
     resp = api("get", path, json=data)
     return resp
-    
+
 
 def get_issue_comment_last_updated(api, urn, comment):
     path = "/repos/{urn}/issues/comments/{comment}".format(urn=urn, comment=comment)

--- a/github_api/issues.py
+++ b/github_api/issues.py
@@ -16,6 +16,13 @@ def open_issue(api, urn, issue_id):
     return resp
 
 
+def get_open_issues(api, urn):
+    path = "/repos/{urn}/issues".format(urn=urn)
+    data = {"state": "open"}
+    resp = api("get", path, json=data)
+    return resp
+    
+
 def get_issue_comment_last_updated(api, urn, comment):
     path = "/repos/{urn}/issues/comments/{comment}".format(urn=urn, comment=comment)
     comment = api("get", path)

--- a/github_api/misc.py
+++ b/github_api/misc.py
@@ -1,5 +1,6 @@
 from math import log
 
+
 def dt_to_github_dt(dt):
     return dt.isoformat() + "Z"
 

--- a/settings.py
+++ b/settings.py
@@ -95,6 +95,6 @@ CHAOSBOT_FAILURE_FILE = "/tmp/chaosbot_failed"
 # If you are going to change it, change it there too.
 CHAOSBOT_STDERR_LOG = "/var/log/supervisor/chaos-stderr.log"
 
-# The threshold for how old an issue has to be without comments before we try to 
+# The threshold for how old an issue has to be without comments before we try to
 # auto-close it. i.e. if an issue goes this long without comments
 ISSUE_STALE_THRESHOLD = 60 * 60 * 24 * 3  # 3 days

--- a/settings.py
+++ b/settings.py
@@ -38,8 +38,8 @@ TEST = False
 
 # the number of seconds chaosbot should sleep between polling for ready prs
 PULL_REQUEST_POLLING_INTERVAL_SECONDS = 30
-ISSUE_COMMENT_POLLING_INTERVAL_SECONDS = 60 * 10  # 10 min window on polling comments
-ISSUE_CLOSE_STALE_INTERVAL_SECONDS = 60 * 10  # 10 min window on polling issues
+ISSUE_COMMENT_POLLING_INTERVAL_SECONDS = 60 * 10  # 10 min interval on polling comments
+ISSUE_CLOSE_STALE_INTERVAL_SECONDS = 60 * 60 * 2  # 2 hour interval on polling issues
 
 # The default number of hours for how large the voting window is
 DEFAULT_VOTE_WINDOW = 3.0

--- a/settings.py
+++ b/settings.py
@@ -39,6 +39,7 @@ TEST = False
 # the number of seconds chaosbot should sleep between polling for ready prs
 PULL_REQUEST_POLLING_INTERVAL_SECONDS = 30
 ISSUE_COMMENT_POLLING_INTERVAL_SECONDS = 60 * 10  # 10 min window on polling comments
+ISSUE_CLOSE_STALE_INTERVAL_SECONDS = 60 * 10  # 10 min window on polling issues
 
 # The default number of hours for how large the voting window is
 DEFAULT_VOTE_WINDOW = 3.0
@@ -93,3 +94,7 @@ CHAOSBOT_FAILURE_FILE = "/tmp/chaosbot_failed"
 # The location of error log -- also found in the supervisor conf.
 # If you are going to change it, change it there too.
 CHAOSBOT_STDERR_LOG = "/var/log/supervisor/chaos-stderr.log"
+
+# The threshold for how old an issue has to be without comments before we try to 
+# auto-close it. i.e. if an issue goes this long without comments
+ISSUE_STALE_THRESHOLD = 60 * 60 * 24 * 3  # 3 days


### PR DESCRIPTION
- Make chaosbot poll every once in a while to see if older issues have been updated.

- Issues that have not been commented on in 3 days get a `/vote close` from chaosbot

- If you want to keep the issue open, you can down vote on that post via the normal mechanisms

Motivation: clean up the clutter so that only issues that people are actively discussing are on the issue viewer...