### PR TITLE
Add a meritocracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Wondering how to contribute? Try implementing a feature requested [here](https:/
 Votes on a PR are determined through following mechanism:
 * A comment that contains an emoji signifying a vote somewhere in the body counts as a vote for
   or against the PR.
-* Same for reactions on the PR itself and an accept/reject [pull
-  request review](https://help.github.com/articles/about-pull-request-reviews/)
+* Same for reactions on the PR itself
 * The PR itself counts as :+1: from the owner, unless they vote otherwise.
 * Voting goes on for the duration of the voting window - currently 2 or 3 hours,
   depending on the local server time.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ will manually be restarted and the death counter will be incremented.
 A: Users must vote on your PR, through either a comment or reaction,
 or a accept/reject pull request review.  See [Voting](https://github.com/chaosbot/Chaos/blob/master/README.md#voting).
 
+In addition, a member of the meritocracy must approve the most recent commit of the PR with a review.
+A member of the meritocracy approving their own PR does not count.
+The meritocracy is determined by combining the top 10 contributors and the top 10 voters.
+Both of those datasets are publicly available, or you can look in chaosbot's logs to determine the current meritocracy.
+
 #### Q: What if ChaosBot has a problem that can't be solved by a PR?
 A: Please open a [project issue](https://github.com/chaosbot/Chaos/issues) and a
 real live human will take a look at it.

--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -23,99 +23,114 @@ def poll_pull_requests(api):
     # get all ready prs (disregarding of the voting window)
     prs = gh.prs.get_ready_prs(api, settings.URN, 0)
 
-    needs_update = False
-    for pr in prs:
-        pr_num = pr["number"]
-        __log.info("processing PR #%d", pr_num)
+    # This sets up a voting record, with each user having a count of votes
+    # that they have cast.
+    try:
+        fp = open('server/voters.json', 'x')
+        fp.close()
+    except:
+        # file already exists, which is what we want
+        pass
 
-        # gather all current votes
-        votes = gh.voting.get_votes(api, settings.URN, pr)
+    with open('server/voters.json', 'r+') as fp:
+        total_votes = {}
+        fs = fp.read()
+        if fs:
+            # if the voting record exists, read it in
+            total_votes = json.loads(fs)
+            # then prepare for overwriting
+            fp.seek(0)
+            fp.truncate()
 
-        # is our PR approved or rejected?
-        vote_total, variance = gh.voting.get_vote_sum(api, votes)
-        threshold = gh.voting.get_approval_threshold(api, settings.URN)
-        is_approved = vote_total >= threshold
+        top_contributors = sorted(gh.repos.get_contributors(api, settings.URN),
+                                  key=lambda user: user["total"])
+        top_contributors = top_contributors[:settings.MERITOCRACY_TOP_CONTRIBUTORS]
+        top_contributors = [user["login"].lower() for user in top_contributors]
+        top_voters = sorted(total_votes.items(), key=lambda k, v: (v, k))
+        top_voters = [user[0].lower() for user in top_voters[:settings.MERITOCRACY_TOP_VOTERS]]
+        meritocracy = top_voters + top_contributors
 
-        # the PR is mitigated or the threshold is not reached ?
-        if variance >= threshold or not is_approved:
-            voting_window = gh.voting.get_extended_voting_window(api, settings.URN)
+        needs_update = False
+        for pr in prs:
+            pr_num = pr["number"]
+            __log.info("processing PR #%d", pr_num)
 
-        # is our PR in voting window?
-        in_window = gh.prs.is_pr_in_voting_window(pr, voting_window)
+            # gather all current votes
+            votes, meritocracy_satisfied = gh.voting.get_votes(api, settings.URN, pr, meritocracy)
 
-        if is_approved:
-            __log.info("PR %d status: will be approved", pr_num)
+            # is our PR approved or rejected?
+            vote_total, variance = gh.voting.get_vote_sum(api, votes)
+            threshold = gh.voting.get_approval_threshold(api, settings.URN)
+            is_approved = vote_total >= threshold and meritocracy_satisfied
 
-            gh.prs.post_accepted_status(
-                api, settings.URN, pr, voting_window, votes, vote_total, threshold)
+            # the PR is mitigated or the threshold is not reached ?
+            if variance >= threshold or not is_approved:
+                voting_window = gh.voting.get_extended_voting_window(api, settings.URN)
 
-            if in_window:
-                __log.info("PR %d approved for merging!", pr_num)
+            # is our PR in voting window?
+            in_window = gh.prs.is_pr_in_voting_window(pr, voting_window)
 
-                try:
-                    sha = gh.prs.merge_pr(api, settings.URN, pr, votes, vote_total,
-                                          threshold)
-                # some error, like suddenly there's a merge conflict, or some
-                # new commits were introduced between finding this ready pr and
-                # merging it
-                except gh.exceptions.CouldntMerge:
-                    __log.info("couldn't merge PR %d for some reason, skipping",
-                               pr_num)
-                    gh.prs.label_pr(api, settings.URN, pr_num, ["can't merge"])
-                    continue
+            if is_approved:
+                __log.info("PR %d status: will be approved", pr_num)
 
-                gh.comments.leave_accept_comment(
-                    api, settings.URN, pr_num, sha, votes, vote_total, threshold)
-                gh.prs.label_pr(api, settings.URN, pr_num, ["accepted"])
+                gh.prs.post_accepted_status(
+                    api, settings.URN, pr, voting_window, votes, vote_total,
+                    threshold, meritocracy_satisfied)
 
-                # chaosbot rewards merge owners with a follow
-                pr_owner = pr["user"]["login"]
-                gh.users.follow_user(api, pr_owner)
+                if in_window:
+                    __log.info("PR %d approved for merging!", pr_num)
 
-                needs_update = True
+                    try:
+                        sha = gh.prs.merge_pr(api, settings.URN, pr, votes, vote_total,
+                                              threshold, meritocracy_satisfied)
+                    # some error, like suddenly there's a merge conflict, or some
+                    # new commits were introduced between finding this ready pr and
+                    # merging it
+                    except gh.exceptions.CouldntMerge:
+                        __log.info("couldn't merge PR %d for some reason, skipping",
+                                   pr_num)
+                        gh.prs.label_pr(api, settings.URN, pr_num, ["can't merge"])
+                        continue
 
-        else:
-            __log.info("PR %d status: will be rejected", pr_num)
+                    gh.comments.leave_accept_comment(
+                        api, settings.URN, pr_num, sha, votes, vote_total,
+                        threshold, meritocracy_satisfied)
+                    gh.prs.label_pr(api, settings.URN, pr_num, ["accepted"])
 
-            if in_window:
-                gh.prs.post_rejected_status(
-                    api, settings.URN, pr, voting_window, votes, vote_total, threshold)
-                __log.info("PR %d rejected, closing", pr_num)
-                gh.comments.leave_reject_comment(
-                    api, settings.URN, pr_num, votes, vote_total, threshold)
-                gh.prs.label_pr(api, settings.URN, pr_num, ["rejected"])
-                gh.prs.close_pr(api, settings.URN, pr)
-            elif vote_total < 0:
-                gh.prs.post_rejected_status(
-                    api, settings.URN, pr, voting_window, votes, vote_total, threshold)
+                    # chaosbot rewards merge owners with a follow
+                    pr_owner = pr["user"]["login"]
+                    gh.users.follow_user(api, pr_owner)
+
+                    needs_update = True
+
             else:
-                gh.prs.post_pending_status(
-                    api, settings.URN, pr, voting_window, votes, vote_total, threshold)
+                __log.info("PR %d status: will be rejected", pr_num)
 
-        # This sets up a voting record, with each user having a count of votes
-        # that they have cast.
-        try:
-            fp = open('server/voters.json', 'x')
-            fp.close()
-        except:
-            # file already exists, which is what we want
-            pass
-
-        with open('server/voters.json', 'r+') as fp:
-            old_votes = {}
-            fs = fp.read()
-            if fs:
-                # if the voting record exists, read it in
-                old_votes = json.loads(fs)
-                # then prepare for overwriting
-                fp.seek(0)
-                fp.truncate()
-            for user in votes:
-                if user in old_votes:
-                    old_votes[user] += 1
+                if in_window:
+                    gh.prs.post_rejected_status(
+                        api, settings.URN, pr, voting_window, votes, vote_total,
+                        threshold, meritocracy_satisfied)
+                    __log.info("PR %d rejected, closing", pr_num)
+                    gh.comments.leave_reject_comment(
+                        api, settings.URN, pr_num, votes, vote_total, threshold,
+                        meritocracy_satisfied)
+                    gh.prs.label_pr(api, settings.URN, pr_num, ["rejected"])
+                    gh.prs.close_pr(api, settings.URN, pr)
+                elif vote_total < 0:
+                    gh.prs.post_rejected_status(
+                        api, settings.URN, pr, voting_window, votes, vote_total,
+                        threshold, meritocracy_satisfied)
                 else:
-                    old_votes[user] = 1
-            json.dump(old_votes, fp)
+                    gh.prs.post_pending_status(
+                        api, settings.URN, pr, voting_window, votes, vote_total,
+                        threshold, meritocracy_satisfied)
+
+            for user in votes:
+                if user in total_votes:
+                    total_votes[user] += 1
+                else:
+                    total_votes[user] = 1
+            json.dump(total_votes, fp)
 
             # flush all buffers because we might restart, which could cause a crash
             os.fsync(fp)

--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -43,12 +43,13 @@ def poll_pull_requests(api):
             fp.truncate()
 
         top_contributors = sorted(gh.repos.get_contributors(api, settings.URN),
-                                  key=lambda user: user["total"])
+                                  key=lambda user: user["total"], reverse=True)
         top_contributors = top_contributors[:settings.MERITOCRACY_TOP_CONTRIBUTORS]
-        top_contributors = [user["login"].lower() for user in top_contributors]
-        top_voters = sorted(total_votes.items(), key=lambda k, v: (v, k))
-        top_voters = [user[0].lower() for user in top_voters[:settings.MERITOCRACY_TOP_VOTERS]]
-        meritocracy = top_voters + top_contributors
+        top_contributors = set([item["author"]["login"].lower() for item in top_contributors])
+        top_voters = sorted(total_votes, key=total_votes.get, reverse=True)
+        top_voters = set([user.lower() for user in top_voters[:settings.MERITOCRACY_TOP_VOTERS]])
+        meritocracy = top_voters | top_contributors
+        __log.info("generated meritocracy: " + str(meritocracy))
 
         needs_update = False
         for pr in prs:

--- a/github_api/comments.py
+++ b/github_api/comments.py
@@ -33,8 +33,8 @@ def get_reactions_for_comment(api, urn, comment_id):
         yield reaction
 
 
-def leave_reject_comment(api, urn, pr, votes, total, threshold):
-    votes_summary = prs.formatted_votes_summary(votes, total, threshold)
+def leave_reject_comment(api, urn, pr, votes, total, threshold, meritocracy_satisfied):
+    votes_summary = prs.formatted_votes_summary(votes, total, threshold, meritocracy_satisfied)
     body = """
 :no_good: PR rejected {summary}.
 
@@ -43,8 +43,8 @@ Open a new PR to restart voting.
     return leave_comment(api, urn, pr, body)
 
 
-def leave_accept_comment(api, urn, pr, sha, votes, total, threshold):
-    votes_summary = prs.formatted_votes_summary(votes, total, threshold)
+def leave_accept_comment(api, urn, pr, sha, votes, total, threshold, meritocracy_satisfied):
+    votes_summary = prs.formatted_votes_summary(votes, total, threshold, meritocracy_satisfied)
     body = """
 :ok_woman: PR passed {summary}.
 

--- a/github_api/repos.py
+++ b/github_api/repos.py
@@ -30,3 +30,8 @@ def get_creation_date(api, urn):
     """ returns the creation date of the repo """
     data = api("get", get_path(urn))
     return arrow.get(data["created_at"])
+
+
+def get_contributors(api, urn):
+    """ returns the list of contributors to the repo """
+    return api("get", "/repos/{urn}/stats/contributors".format(urn=urn))

--- a/github_api/voting.py
+++ b/github_api/voting.py
@@ -31,6 +31,7 @@ def get_votes(api, urn, pr, meritocracy):
         if (vote > 0 and is_current and vote_owner != pr_owner
                 and vote_owner.lower() in meritocracy):
             meritocracy_satisfied = True
+            break
 
     # by virtue of creating the PR, the owner defaults to a vote of 1
     if votes.get(pr_owner) != -1:

--- a/github_api/voting.py
+++ b/github_api/voting.py
@@ -10,7 +10,7 @@ from . import repos
 import settings
 
 
-def get_votes(api, urn, pr):
+def get_votes(api, urn, pr, meritocracy):
     """ return a mapping of username => -1 or 1 for the votes on the current
     state of a pr.  we consider comments and reactions, but only from users who
     are not the owner of the pr.  we also make sure that the voting
@@ -18,6 +18,7 @@ def get_votes(api, urn, pr):
     can't acquire approval votes, then change the pr """
 
     votes = {}
+    meritocracy_satisfied = False
     pr_owner = pr["user"]["login"]
     pr_num = pr["number"]
 
@@ -26,15 +27,16 @@ def get_votes(api, urn, pr):
         votes[voter] = vote
 
     # get all the pr-review-based votes
-    for vote_owner, vote in get_pr_review_votes(api, urn, pr_num):
-        if vote and vote_owner != pr_owner:
-            votes[vote_owner] = vote
+    for vote_owner, is_current, vote in get_pr_review_votes(api, urn, pr):
+        if (vote > 0 and is_current and vote_owner != pr_owner
+                and vote_owner.lower() in meritocracy):
+            meritocracy_satisfied = True
 
     # by virtue of creating the PR, the owner defaults to a vote of 1
     if votes.get(pr_owner) != -1:
         votes[pr_owner] = 1
 
-    return votes
+    return votes, meritocracy_satisfied
 
 
 def get_pr_comment_votes_all(api, urn, pr_num):
@@ -94,15 +96,16 @@ def get_comment_reaction_votes(api, urn, comment_id):
             yield reaction_owner, vote
 
 
-def get_pr_review_votes(api, urn, pr_num):
+def get_pr_review_votes(api, urn, pr):
     """ votes made through
     https://help.github.com/articles/about-pull-request-reviews/ """
-    for review in prs.get_pr_reviews(api, urn, pr_num):
+    for review in prs.get_pr_reviews(api, urn, pr["number"]):
         state = review["state"]
         if state in ("APPROVED", "DISMISSED"):
             user = review["user"]["login"]
+            is_current = review["commit_id"] == pr["head"]["sha"]
             vote = parse_review_for_vote(state)
-            yield user, vote
+            yield user, is_current, vote
 
 
 def get_vote_weight(api, username):

--- a/patch.py
+++ b/patch.py
@@ -30,3 +30,4 @@ api_memoize = partial(memoize, blacklist={"api"}, backend=json_backend(cache_dir
 decorate(github_api.voting.get_vote_weight, api_memoize("1d"))
 decorate(github_api.repos.get_num_watchers, api_memoize("10m"))
 decorate(github_api.prs.get_is_mergeable, api_memoize("2m"))
+decorate(github_api.repos.get_contributors, api_memoize("1d"))

--- a/settings.py
+++ b/settings.py
@@ -98,3 +98,9 @@ CHAOSBOT_STDERR_LOG = "/var/log/supervisor/chaos-stderr.log"
 # The threshold for how old an issue has to be without comments before we try to
 # auto-close it. i.e. if an issue goes this long without comments
 ISSUE_STALE_THRESHOLD = 60 * 60 * 24 * 3  # 3 days
+
+# The top n contributors will be allowed in the meritocracy
+MERITOCRACY_TOP_CONTRIBUTORS = 10
+
+# The top n voters will be allowed in the meritocracy
+MERITOCRACY_TOP_VOTERS = 10


### PR DESCRIPTION
I decided to not go with a clickbait title this time :smile:

Look at #361 for more details, but **I tried to give the meritocracy minimal power. Democracy still decides the outcome >90% of the time.** This is just to prevent against sneaky take over attempts.

Basis of how it works:

> At least one positive non-author meritocracy review on the most recent commit of a PR is required for that PR to be accepted.

Changes from #361:

- Autogenerate meritocracy list (currently top 10 contributors + top 10 voters)
- Don't count reviews as votes (so members of the meritocracy can allow a PR without voting for it)