### PR TITLE
Bug fix for fatal error (from #389)

### DIFF
--- a/cron/poll_read_issue_comments.py
+++ b/cron/poll_read_issue_comments.py
@@ -235,7 +235,6 @@ def poll_read_issue_comments(api):
     __log.info("looking for issue comments")
 
     issue_comments = gh.comments.get_all_issue_comments(api, settings.URN)
-    __log.info("found {count} issue comments".format(count=len(issue_comments)))
 
     for issue_comment in issue_comments:
         handle_comment(api, issue_comment)


### PR DESCRIPTION
Can't grab the length of a generator. This log line isn't needed anyways.