### PR TITLE
Linkify "ChaoBot's logs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ or a accept/reject pull request review.  See [Voting](https://github.com/chaosbo
 In addition, a member of the meritocracy must approve the most recent commit of the PR with a review.
 A member of the meritocracy approving their own PR does not count.
 The meritocracy is determined by combining the top 10 contributors and the top 10 voters.
-Both of those datasets are publicly available, or you can look in [chaosbot's logs](http://chaosthebot.com:8081/chaos-stderr.log) to determine the current meritocracy.
+Both of those datasets are publicly available, or you can look in [chaosbot's logs](http://chaosthebot.com:8081/chaos-stderr.log) (search for "generated meritocracy"; the last is most recent) to determine the current meritocracy.
 
 #### Q: What if ChaosBot has a problem that can't be solved by a PR?
 A: Please open a [project issue](https://github.com/chaosbot/Chaos/issues) and a

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ or a accept/reject pull request review.  See [Voting](https://github.com/chaosbo
 In addition, a member of the meritocracy must approve the most recent commit of the PR with a review.
 A member of the meritocracy approving their own PR does not count.
 The meritocracy is determined by combining the top 10 contributors and the top 10 voters.
-Both of those datasets are publicly available, or you can look in chaosbot's logs to determine the current meritocracy.
+Both of those datasets are publicly available, or you can look in [chaosbot's logs](http://chaosthebot.com:8081/chaos-stderr.log) to determine the current meritocracy.
 
 #### Q: What if ChaosBot has a problem that can't be solved by a PR?
 A: Please open a [project issue](https://github.com/chaosbot/Chaos/issues) and a


### PR DESCRIPTION
Makes the text "chaosbot's logs" in the README a link to the logs, where people can find the meritocracy information. 