### PR TITLE
Bring back mandatory travis-ci check

### DIFF
--- a/github_api/comments.py
+++ b/github_api/comments.py
@@ -78,6 +78,15 @@ Open a new PR with the merge conflicts fixed to restart voting.
     return leave_comment(api, urn, pr, body)
 
 
+def leave_ci_failed_comment(api, urn, pr, hours):
+    body = """
+:no_good: This PR has failed to pass CI, and hasn't been touched in {hours} hours. Closing.
+
+Open a new PR with the problems fixed to restart voting.
+    """.strip().format(hours=hours)
+    return leave_comment(api, urn, pr, body)
+
+
 def leave_deleted_comment(api, urn, pr):
     body = """
 :no_good: The repository backing this PR has been deleted.

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -233,7 +233,7 @@ def get_ready_prs(api, urn, window):
             build_passed = has_build_passed(api, urn, pr["head"]["sha"])
 
             if not build_passed:
-                issues.label_issue(api, urn, pr_num, ["CI failed"])
+                issues.label_issue(api, urn, pr_num, ["ci failed"])
                 handle_broken_pr(api, urn, pr, delta, "ci")
                 continue
 

--- a/settings.py
+++ b/settings.py
@@ -78,7 +78,8 @@ REPO_LABELS = {
     "rejected": "ededed",
     "conflicts": "fbca04",
     "mergeable": "dddddd",
-    "can't merge": "ededed"
+    "can't merge": "ededed",
+    "ci failed": "ff9800"
 }
 
 # PRs that have merge conflicts and haven't been touched in this many hours

--- a/tests/github_api/misc_test.py
+++ b/tests/github_api/misc_test.py
@@ -31,7 +31,6 @@ class CooldownTests(unittest.TestCase):
         in_2weeks = 14
         in_2month = 60
         far_future = inf  # <- we will never reach this in reality
-        print(voting.dynamic_voting_window(15, 10, 20))
 
         # first day starts at the lower bound
         self.assertEqual(voting.dynamic_voting_window(first_day, 0, 10), 0)

--- a/tests/github_api/prs_test.py
+++ b/tests/github_api/prs_test.py
@@ -2,7 +2,7 @@ import unittest
 import arrow
 from unittest.mock import patch, MagicMock
 
-from github_api import prs, API
+from github_api import prs
 
 
 def create_mock_pr(number, title, pushed_at, created_at):
@@ -11,6 +11,7 @@ def create_mock_pr(number, title, pushed_at, created_at):
         "title": title,
         "statuses_url": "statuses_url/{}".format(number),
         "head": {
+            "sha": "sha{}".format(number),
             "repo": {
                 "pushed_at": pushed_at,
                 "name": "test_repo",
@@ -42,93 +43,96 @@ def create_mock_events(events):
 
 
 class TestPRMethods(unittest.TestCase):
+    def setUp(self):
+        self.api = MagicMock()
+
     def test_statuses_returns_passed_travis_build(self):
-        test_data = [[{"state": "success",
-                     "context": "continuous-integration/travis-ci/pr"}],
+
+        test_data = [
+                     # single successfull run
+                     [{"state": "success",
+                       "context": "continuous-integration/travis-ci/pr"}],
+                     # other contexts don't change result
                      [{"state": "success",
                        "context": "continuous-integration/travis-ci/pr"},
                       {"state": "failure",
                        "context": "chaosbot"}],
+                     # no travis - no problems
+                     [{"state": "pending",
+                       "context": "some_other_context"}]
                      ]
-        pr = "/repos/test/blah"
 
         for statuses in test_data:
-            class Mocked(API):
-                def __call__(m, method, path, **kwargs):
-                    self.assertEqual(pr, path)
-                    return statuses
+            self.api.return_value = {"statuses": statuses}
+            self.assertTrue(prs.has_build_passed(self.api, "urn", "ref"))
+            self.api.assert_called_once_with("get", "/repos/urn/commits/ref/status")
+            self.api.reset_mock()
 
-            api = Mocked("user", "pat")
-            url = "{}{}".format(api.BASE_URL, pr)
-
-            self.assertTrue(prs.has_build_passed(api, url))
-
-    def test_statuses_returns_failed_travis_build_in_wrong_context(self):
-        test_data = [[{"state": "pending",
-                       "context": "some_other_context"}],
-                     [{"state": "success",
-                       "context": "some_other_context"}],
-                     [{"state": "error",
-                       "context": "some_other_other_context"}],
-                     ]
-        pr = "/repos/test/blah"
-
-        for statuses in test_data:
-            class Mocked(API):
-                def __call__(m, method, path, **kwargs):
-                    self.assertEqual(pr, path)
-                    return statuses
-
-            api = Mocked("user", "pat")
-            url = "{}{}".format(api.BASE_URL, pr)
-
-            self.assertFalse(prs.has_build_passed(api, url))
-
-    def test_statuses_returns_failed_travis_build_in_correct_context(self):
-        test_data = [[{"state": "error",
-                     "context": "continuous-integration/travis-ci/pr"}],
+    def test_statuses_returns_failed_travis_build(self):
+        test_data = [
+                     # Travis failed
+                     [{"state": "failure",
+                       "context": "continuous-integration/travis-ci/pr"}],
+                     # Travis pending
                      [{"state": "pending",
                        "context": "continuous-integration/travis-ci/pr"}],
                      ]
-        pr = "/repos/test/blah"
 
         for statuses in test_data:
-            class Mocked(API):
-                def __call__(m, method, path, **kwargs):
-                    self.assertEqual(pr, path)
-                    return statuses
+            self.api.return_value = {"statuses": statuses}
+            self.assertFalse(prs.has_build_passed(self.api, "urn", "ref"))
+            self.api.assert_called_once_with("get", "/repos/urn/commits/ref/status")
+            self.api.reset_mock()
 
-            api = Mocked("user", "pat")
-            url = "{}{}".format(api.BASE_URL, pr)
-
-            self.assertFalse(prs.has_build_passed(api, url))
-
+    @patch("github_api.prs.has_build_passed")
     @patch("github_api.prs.get_events")
     @patch("github_api.prs.get_open_prs")
     @patch("github_api.prs.get_is_mergeable")
     @patch("arrow.utcnow")
     def test_get_ready_prs(self, mock_utcnow, mock_get_is_mergeable,
-                           mock_get_open_prs, mock_get_events):
+                           mock_get_open_prs, mock_get_events, mock_has_build_passed):
+        # Title of each PR describes it's state
         mock_get_open_prs.return_value = [
             create_mock_pr(10, "WIP", "2017-01-01T00:00:00Z", "2017-01-01T00:00:00Z"),
             create_mock_pr(11, "OK", "2017-01-01T00:00:00Z", "2017-01-01T00:00:00Z"),
             create_mock_pr(12, "Not in window", "2017-01-01T00:00:10Z", "2017-01-01T00:00:00Z"),
             create_mock_pr(13, "Not mergeable", "2017-01-01T00:00:00Z", "2017-01-01T00:00:00Z"),
-            create_mock_pr(14, "Stale", "2016-01-01T00:00:00Z", "2017-01-01T00:00:00Z")
+            create_mock_pr(14, "Stale", "2016-01-01T00:00:00Z", "2017-01-01T00:00:00Z"),
+            create_mock_pr(15, "Build failed", "2017-01-01T00:00:00Z", "2017-01-01T00:00:00Z")
         ]
+
+        master_build_status = True
 
         def get_is_mergeable_side_effect(api, urn, pr_num):
             return False if pr_num in [13, 14] else True
 
+        def has_build_passed_side_effect(api, urn, ref):
+            if ref is "master":
+                return master_build_status
+            return False if "15" in ref else True
+
         mock_get_is_mergeable.side_effect = get_is_mergeable_side_effect
+        mock_has_build_passed.side_effect = has_build_passed_side_effect
         mock_utcnow.return_value = arrow.get("2017-01-01T00:00:10Z")
         mock_get_events.return_value = []
         api = MagicMock()
         api.BASE_URL = "api_base_url"
+
+        # In this scenario only PR with number 11 should be returned.
         ready_prs = prs.get_ready_prs(api, "urn", 5)
         ready_prs_list = [pr for pr in ready_prs]
         self.assertEqual(len(ready_prs_list), 1)
         self.assertEqual(ready_prs_list[0].get("number"), 11)
+
+        # Test for the case when master branch is failing.
+        # PR 15 will be also returned in this case as we don't
+        # block PRs if master is also failing
+        master_build_status = False
+        ready_prs = prs.get_ready_prs(api, "urn", 5)
+        ready_prs_list = [pr for pr in ready_prs]
+        self.assertTrue(len(ready_prs_list) is 2)
+        self.assertTrue(ready_prs_list[0].get("number") is 11)
+        self.assertTrue(ready_prs_list[1].get("number") is 15)
 
     @patch("github_api.prs.get_events")
     def test_get_pr_last_updated_with_early_events(self, mock_get_events):


### PR DESCRIPTION
### How it works:
1. Before polling all issues the [status of the `master`](https://api.github.com/repos/chaosbot/chaos/commits/master/status) is checked
1. If and only if it's passing CI(Travis) for each open PR its build status will be checked. 
1. From PR object ([example for this PR](https://api.github.com/repos/chaosbot/chaos/pulls/412)) `sha` of the `head` commit is taken and it's status ([example for this PR](https://api.github.com/repos/chaosbot/chaos/commits/49d954d999429adc3c2874d7015e1e630b693537/status)) is checked.
1. If and only if it's failing PR is marked with `ci failed` label and skipped.
1. ???
1. PROFIT!

### TODO:
- [x] It doesn't block PRs if status is not added for some reason
- [x] Add new label `ci failed` for build with failing CI
- [x] Check current master status - if it fails - do nothing
- [x] Close PRs that can't pass CI for a long time if `master` is okay (as we do with PRs with conflicts)
- [x] Fix and update tests
- [x] Test on my fork
