### PR TITLE
Fix for closing stale issues

### DIFF
--- a/cron/poll_issue_close_stale.py
+++ b/cron/poll_issue_close_stale.py
@@ -17,9 +17,11 @@ def poll_issue_close_stale(api):
     __log.info("Checking for stale issues...")
 
     # Get all issues
-    issues = gh.issues.get_open_issues(api, settings.URN)
+    issues = gh.issues.get_oldest_open_issues(api, settings.URN)
 
-    __log.info("There are currently %d open issues" % len(issues))
+    __log.info(str(issues))
+
+    __log.info("Got the oldest %d open issues" % len(issues))
 
     for issue in issues:
         number = issue["number"]

--- a/github_api/issues.py
+++ b/github_api/issues.py
@@ -16,9 +16,13 @@ def open_issue(api, urn, issue_id):
     return resp
 
 
-def get_open_issues(api, urn):
+def get_oldest_open_issues(api, urn):
     path = "/repos/{urn}/issues".format(urn=urn)
-    data = {"state": "open"}
+    data = {
+            "state": "open",
+            "sort": "updated",
+            "direction": "asc",
+            }
     resp = api("get", path, json=data)
     return resp
 


### PR DESCRIPTION
Github APIs use pagination, so we were getting the newest 30 issues, which are of course not usually stale...