### PR TITLE
Increase crash rollback time to 15min from 60s

### DIFF
--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -23,8 +23,8 @@ start_time=`date +%s`
 failed=$?
 time_elasped=`expr $(date +%s) - $start_time`
 
-if [ "$failed" -ne 0 ] && [ "$time_elasped" -le 60 ]; then
-    echo "Crashed in less than 60 seconds!" >&2
+if [ "$failed" -ne 0 ] && [ "$time_elasped" -le 900 ]; then
+    echo "Crashed in less than 15 minutes!" >&2
 
     # Only rollback if this is the production server...
     ((git remote -v | grep origin | grep -q chaosbot/Chaos) && rollback) || \

--- a/etc/chaos_supervisor.conf
+++ b/etc/chaos_supervisor.conf
@@ -11,8 +11,8 @@ stderr_logfile=/root/workspace/Chaos/log/supervisor-stderr.log
 stderr_logfile_maxbytes=1MB
 stderr_logfile_backups=10
 
-# need to be alive for at least 60s
-startsecs=60
+# need to be alive for at least 15min
+startsecs=900
 
 # retry startup up to 10 times
 startretries=10


### PR DESCRIPTION
i.e. If chaosbot crashes in the first 15min, it will rollback.