### PR TITLE
Prevent animation on first card click

### DIFF
--- a/server/index.html
+++ b/server/index.html
@@ -46,7 +46,7 @@
             <canvas id="cv3"></canvas>
         </div>
         <div class="container">
-            <div id="main" class="card">
+            <div id="main" class="card active">
                 <div class="card-content main has-text-centered">
                     <div class="content-title">
                         <h1 class="title"><strong>Hello, Chaos!</strong></h1>
@@ -64,7 +64,7 @@
                     </span>
                 </div>
             </div>
-            <div id="voters" class="card">
+            <div id="voters" class="card inactive">
                 <div class="card-content main has-text-centered">
                     <div class="content-title">
                         <h1 class="title"><strong>Top Voters on Chaos!</strong></h1>


### PR DESCRIPTION
Currently it animates to show the main card when you click on it after loading the page, even though it's already showing the main card.