### PR TITLE
33% more efficient and a missile launcher inside 🐲

### DIFF
--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -29,10 +29,11 @@ you don't lose it.  Be sure not to commit this file and share it with the world
 
 ### Building the docker image
 
-You can build with `docker-compose build` from the root of the project
-directory, but this is not mandatory (up will do it for you).
 
-Or you also can navigate to `dev/docker/` and run `bash build.sh`.
+Navigate to `dev/docker/`.
+Then you can build with `docker-compose build` but this is not mandatory (up will do it for you).
+
+Or you can run `bash build.sh` instead.
 For Windows, be sure to have docker started, then you can run `build.bat`.
 This will run the Dockerfile and produce your docker image with the name
 `chaos`.
@@ -41,17 +42,17 @@ If you want to build on a Raspberry Pi run `bash build.sh -rpi`.
 
 ## Running
 
-You can simply run `docker-compose up chaos`
-from the root of the project directory.
+Make sure you're in `dev/docker/`.
+You can simply run `docker-compose up chaos`.
 
-Or make sure you're in `dev/docker/` and run `bash run.sh` or `run.bat`.
+Or you can run with `bash run.sh` or `run.bat`.
 
 ## Testing
 
-You can simply run `docker-compose up tests`
-from the root of the project directory.
+Make sure you're in `dev/docker/`.
+You can simply run `docker-compose up tests`.
 
-Or you can run tests with `bash test.sh` or `test.bat` from `dev/docker/`.
+Or you can also run tests with `bash test.sh` or `test.bat`.
 
 ## Development Cycle
 

--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -29,7 +29,10 @@ you don't lose it.  Be sure not to commit this file and share it with the world
 
 ### Building the docker image
 
-To build the docker image, navigate to `dev/docker/` and run `bash build.sh`.
+You can build with `docker-compose build` from the root of the project
+directory, but this is not mandatory (up will do it for you).
+
+Or you also can navigate to `dev/docker/` and run `bash build.sh`.
 For Windows, be sure to have docker started, then you can run `build.bat`.
 This will run the Dockerfile and produce your docker image with the name
 `chaos`.
@@ -38,11 +41,17 @@ If you want to build on a Raspberry Pi run `bash build.sh -rpi`.
 
 ## Running
 
-Make sure you're in `dev/docker/` and run `bash run.sh` or `run.bat`.
+You can simply run `docker-compose up chaos`
+from the root of the project directory.
+
+Or make sure you're in `dev/docker/` and run `bash run.sh` or `run.bat`.
 
 ## Testing
 
-You can run tests with `bash test.sh` or `test.bat`.
+You can simply run `docker-compose up tests`
+from the root of the project directory.
+
+Or you can run tests with `bash test.sh` or `test.bat` from `dev/docker/`.
 
 ## Development Cycle
 

--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -34,11 +34,15 @@ For Windows, be sure to have docker started, then you can run `build.bat`.
 This will run the Dockerfile and produce your docker image with the name
 `chaos`.
 
-If you want to build on a Raspberry Pi run `bash build.sh -rpi`
+If you want to build on a Raspberry Pi run `bash build.sh -rpi`.
 
 ## Running
 
 Make sure you're in `dev/docker/` and run `bash run.sh` or `run.bat`.
+
+## Testing
+
+You can run tests with `bash test.sh` or `test.bat`.
 
 ## Development Cycle
 

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   chaos:
     image: chaos
     build:
-      context: .
+      context: ../..
       dockerfile: ./dev/docker/Dockerfile
     command: bash /root/workspace/Chaos/dev/docker/start_services.sh
     links:
@@ -12,16 +12,16 @@ services:
       - 8082:80
       - 8081:8081
     volumes:
-      - .:/root/workspace/Chaos
-
+      - ../..:/root/workspace/Chaos
+      
   tests:
     image: chaos
     build:
-      context: .
+      context: ../..
       dockerfile: ./dev/docker/Dockerfile
     command: python -m unittest discover -p *_test.py
     volumes:
-      - .:/root/workspace/Chaos
+      - ../..:/root/workspace/Chaos
 
   db:
      image: mysql:5.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3'
+services:
+  chaos:
+    image: chaos
+    build:
+      context: .
+      dockerfile: ./dev/docker/Dockerfile
+    command: bash /root/workspace/Chaos/dev/docker/start_services.sh
+    links:
+      - db
+    ports:
+      - 8082:80
+      - 8081:8081
+    volumes:
+      - .:/root/workspace/Chaos
+
+  tests:
+    image: chaos
+    build:
+      context: .
+      dockerfile: ./dev/docker/Dockerfile
+    command: python -m unittest discover -p *_test.py
+    volumes:
+      - .:/root/workspace/Chaos
+
+  db:
+     image: mysql:5.7
+     volumes:
+       - db_data:/var/lib/mysql
+     environment:
+       MYSQL_ROOT_PASSWORD: P145M4P0W3R
+       MYSQL_DATABASE: db
+       MYSQL_USER: chaos
+       MYSQL_PASSWORD: chaos
+
+volumes:
+  db_data:
+    driver: local


### PR DESCRIPTION
This PR has nothing to do with a missile launcher or a dragon, sorry.

BUT now we have a docker-compose file to simply run Chaos and tests (so it's based on #422 an #428)
- docker-compose is simple for running docker commands
- crossplatform : no need of 6 scripts (run.sh, tests.bat, etc…)

Only 2 commands to rule them all :
- `docker-compose up tests` will run… tests
- `docker-compose up chaos` will run… Chaos!