### PR TITLE
Upgrade requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ appdirs==1.4.3
 arrow==0.10.0
 asn1crypto==0.22.0
 cffi==1.10.0
-cryptography==1.8.1
+cryptography==1.9
 emoji==0.4.5
 enum34==1.1.6
 idna==2.5
@@ -18,7 +18,7 @@ pycrypto==2.6.1
 pyparsing==2.2.0
 python-dateutil==2.6.0
 PyYAML==3.12
-requests==2.14.2
+requests==2.17.3
 schedule==0.4.2
 sh==1.12.13
 six==1.10.0


### PR DESCRIPTION
The previous version of `cryptography` failed to build on my system because I had openssl 1.1. The new version fixes that. I also upgraded `requests` for good measure.

Reminder for meritocracy review :)