### PR TITLE
Fix docker build by installing six before req's

### DIFF
--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -47,6 +47,7 @@ ENV PATH="$venv/bin:$PATH"
 
 WORKDIR $chaosdir
 
+RUN pip install six
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 RUN rm requirements.txt


### PR DESCRIPTION
Previously, `docker-compose build` in `/dev/docker/` was failing due to
`ModuleNotFoundError`s for six.