### PR TITLE
Claim responsibility of the chaos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,106 @@
+Chaos <andrew@formconstantdance.org>
+Andrew Moffat <arwmoffat@gmail.com>
+chaosbot <andrew@formconstantdance.org>
+Lee Bousfield <ljbousfield@gmail.com>
+Joram van den Boezem <joram@nabble.nl>
+Alexander F Rødseth <rodseth@gmail.com>
+eukaryote <eukaryote31@users.noreply.github.com>
+rudehn <nrude93@gmail.com>
+Léo GRAND <leograndcontact@gmail.com>
+Jeremy Cantu <jcantu521@gmail.com>
+md678685 <mathew678@hotmail.co.uk>
+Adam Dobrawy <naczelnik@jawnosc.tk>
+Alex Bradley <abrad12122@gmail.com>
+Jonathan Pepler <jonpepler@Jons-MacBook-Pro.local>
+much <much@localhost.localdomain>
+pchauncey <pchauncey@gmail.com>
+Richard <richard.anaya@gmail.com>
+Who? Me?! <mark-i-m@users.noreply.github.com>
+ozyx <jessemazzella@gmail.com>
+ECrownofFire <ecrownoffire@gmail.com>
+J0hn- <jonathan.platteau@yahoo.fr>
+Gustavo Rodrigues <qgustavor@users.noreply.github.com>
+MRHwick <MatthewRHardwick@gmail.com>
+Unknown <dehodson@gmail.com>
+scaule <scaule@clever-age.com>
+Phil Rukin <philipp@rukin.me>
+golergka <golergka@Gmail.com>
+DasSkelett <DasSkelett@users.noreply.github.com>
+Ben Barth <benbarth@users.noreply.github.com>
+Joseph Hassell <josephh2018@gmail.com>
+eukaryote <minerguy31@gmail.com>
+Alex <alexisr245@gmail.com>
+Phil <phil.ficus@gmail.com>
+John <J0hn-@users.noreply.github.com>
+Konrad Borowski <xfix@protonmail.com>
+Tarun <tarun.batra00@gmail.com>
+Konrad Borowski <x.fix@o2.pl>
+Andrew Dassonville <dassonville.andrew@gmail.com>
+Matthew Hardwick <mrhwick@users.noreply.github.com>
+Patrick Chauncey <pchauncey@gmail.com>
+Patrick Nelson <patnelson@ebay.com>
+Peter Geiss <pgeiss@users.noreply.github.com>
+Quentin Gerodel <Swizz@users.noreply.github.com>
+Jeff Bowen <jblz@users.noreply.github.com>
+Smittyvb <smittyvb@gmail.com>
+Carson Radtke <8radtke@arrowheadschools.org>
+Tibor Nagy <xnagytibor@gmail.com>
+John <flibustier@users.noreply.github.com>
+Jon Paul Uritis <jonpaul.act@gmail.com>
+eamanu <emmanuelarias30@gmail.com>
+hawkfalcon <contact@hawkfalcon.com>
+jakejdavis <jakeyjdavis@gmail.com>
+Jon Paul Uritis <jonpaul@lojistic.com>
+Jon Pepler <jon1467@users.noreply.github.com>
+philipz <philipzheng@gmail.com>
+KnappeGEIL <KnappeGEIL@users.noreply.github.com>
+KnappeGEIL <fabian@bermel.org>
+Drew Hodson <dehodson@gmail.com>
+Leon Mok <mok.leon@gmail.com>
+Anthony Alves <Cvballa3g0@gmail.com>
+MINIMAN10000 <miniman10000@gmail.com>
+Anthony Nixon <ajn0592@gmail.com>
+Paul <paul.a.dibiase@gmail.com>
+Adrian Legaspi <aki.legaspi@gmail.com>
+Alois <aloisdegouvello@live.fr>
+Ameliorate <Ameliorate@users.noreply.github.com>
+Arturs Demiters <arturs@codecraft.lv>
+Benjamin Manns <benmanns@gmail.com>
+Bradley Monk <brad.monk@gmail.com>
+Campbell <The6P4C@users.noreply.github.com>
+Carson Radtke <carsonRadtke@users.noreply.github.com>
+Dave Hughes <DHughes@XumaK.com>
+ELI JOSEPH BRADLEY <EtherTyper@users.noreply.github.com>
+Ethan Madden <maddene@madden.ninja>
+Evan Hopper-Moore <evanhoppermoore@gmail.com>
+GRAND Léo <leograndcontact@gmail.com>
+Gökberk Yaltıraklı <webdosusb@gmail.com>
+Jacob <brokendwarf@gmail.com>
+James Watling <james@guavapass.com>
+Jeff Bowen <jeff@automattic.com>
+Jesse Mazzella <ozyx@users.noreply.github.com>
+Josh Grigonis <josh.grigonis@gmail.com>
+Kevin Godby <godbyk@gmail.com>
+Kevin Kielholz <kevinkielholz@web.de>
+Leigende <alexisr245@gmail.com>
+Léo <leograndcontact@gmail.com>
+MINIMAN10000 <gamerboy10000@comcast.net>
+Makeitude <jamie@makeitude.com.au>
+Michael Giuffrida <michaelg@michaelg.us>
+OpenNingia <oppifjellet@gmail.com>
+Adam Dobrawy <ad-m@users.noreply.github.com>
+Paul Di Biase <paul.a.dibiase@gmail.com>
+Piotr Kuszaj <kuszaj@users.noreply.github.com>
+Piotr Kuszaj <peterkuszaj@gmail.com>
+Rafael Hengles <rafael@hengles.net>
+Ryan Belgrave <rmb1993@gmail.com>
+The6P4C <watsonjcampbell@gmail.com>
+Theodore Dubois <tbodt@users.noreply.github.com>
+Viktor Seč <hey@viktorsec.com>
+YannSpoeri <yann_spoeri@web.de>
+abrad1212 <abrad12122@gmail.com>
+davidak <davidak@users.noreply.github.com>
+jgrigonis <josh.grigonis@gmail.com>
+marcosrjjunior <marcosrjjunior@gmail.com>
+meltahawy <mohamedeltahawy@Mohameds-MacBook-Pro.local>
+reddraggone9 <cljenkins9@gmail.com>

--- a/tools/update_authors.sh
+++ b/tools/update_authors.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+git shortlog -e -s -n | cut -f2-  > AUTHORS
+git add AUTHORS
+# git commit -m "Updating authors"


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5329230/26666845/c70cb3ca-46bf-11e7-94cd-e545fcb0e5d9.png)
With Great Power comes Great Responsibility

We already have the voters list on the site. I thought it is necessary that the Authors are publicly visible, and regularly updated by the @chaosbot.

I couldn't make it updated automatically by chaosbot. But I call upon the leaders of the repo to pour in your contributions to make it work.

