### PR TITLE
Ensure labels creation

### DIFF
--- a/chaos.py
+++ b/chaos.py
@@ -61,6 +61,13 @@ def main():
     log.info("Setting description to {desc}".format(desc=settings.REPO_DESCRIPTION))
     github_api.repos.set_desc(api, settings.URN, settings.REPO_DESCRIPTION)
 
+    log.info("Ensure creation of issue/PR labels")
+    github_api.repos.create_label(api, settings.URN, "accepted", "0e8a16")
+    github_api.repos.create_label(api, settings.URN, "rejected", "ededed")
+    github_api.repos.create_label(api, settings.URN, "conflicts", "fbca04")
+    github_api.repos.create_label(api, settings.URN, "mergeable", "dddddd")
+    github_api.repos.create_label(api, settings.URN, "can't merge", "ededed")
+
     while True:
         # Run any scheduled jobs on the next second.
         schedule.run_pending()

--- a/chaos.py
+++ b/chaos.py
@@ -62,11 +62,8 @@ def main():
     github_api.repos.set_desc(api, settings.URN, settings.REPO_DESCRIPTION)
 
     log.info("Ensure creation of issue/PR labels")
-    github_api.repos.create_label(api, settings.URN, "accepted", "0e8a16")
-    github_api.repos.create_label(api, settings.URN, "rejected", "ededed")
-    github_api.repos.create_label(api, settings.URN, "conflicts", "fbca04")
-    github_api.repos.create_label(api, settings.URN, "mergeable", "dddddd")
-    github_api.repos.create_label(api, settings.URN, "can't merge", "ededed")
+    for label, color in settings.REPO_LABELS.items():
+        github_api.repos.create_label(api, settings.URN, label, color)
 
     while True:
         # Run any scheduled jobs on the next second.

--- a/github_api/repos.py
+++ b/github_api/repos.py
@@ -35,3 +35,12 @@ def get_creation_date(api, urn):
 def get_contributors(api, urn):
     """ returns the list of contributors to the repo """
     return api("get", "/repos/{urn}/stats/contributors".format(urn=urn))
+
+
+def create_label(api, urn, name, color="ededed"):
+    """ create an issue label for the repository """
+    data = {
+        "name": name,
+        "color": color
+    }
+    return api("post", "/repos/{urn}/labels".format(urn=urn), json=data)

--- a/settings.py
+++ b/settings.py
@@ -72,6 +72,15 @@ TIMEZONE = "US/Pacific"
 with open("description.txt", "r") as h:
     REPO_DESCRIPTION = h.read().strip()
 
+# repo labels
+REPO_LABELS = {
+    "accepted": "0e8a16",
+    "rejected": "ededed",
+    "conflicts": "fbca04",
+    "mergeable": "dddddd",
+    "can't merge": "ededed"
+}
+
 # PRs that have merge conflicts and haven't been touched in this many hours
 # will be closed
 PR_STALE_HOURS = 36


### PR DESCRIPTION
Repo labels could be deleted any time.

So could we attempt to create them at startup (like description) ?

(If a label name already exist, the api call will be silently ignored)

edit : just seen I shipped 27b8b65 from #435 is this a problem with our squash enabled strategy ?