### PR TITLE
FIX ERROR PAGES WITH THIS ONE SIMPLE TRICK

### DIFF
--- a/server/error.html
+++ b/server/error.html
@@ -5,7 +5,7 @@
         <meta charset="utf-8">
     </head>
     <body>
-        <p id="code">%(code)s<p>
+        <p id="code">%(code)d<p>
         <p id="message">%(message)s</p>
         <p id="explain">%(explain)s</p>
         <p id="link"><a href="/">Return to main page</a></p>


### PR DESCRIPTION
This fixes the display of the error code in #439 - the previous page worked on Python 3.4 (installed by default by Vagrant until #454), but the way error codes work for SimpleHTTPRequestListener changed in Python 3.5.