### PR TITLE
fix invalid syntax

### DIFF
--- a/lib/db.py
+++ b/lib/db.py
@@ -4,7 +4,6 @@
 from importlib import import_module
 
 import settings
-from lib.db_adapters.interface import AbstractAdapter
 
 
 class DB(object):

--- a/lib/db.py
+++ b/lib/db.py
@@ -20,7 +20,7 @@ class DB(object):
         return DB.instance
 
     @staticmethod
-    def create_adapter(adapter_name, config) -> AbstractAdapter:
+    def create_adapter(adapter_name, config):
         """ helper method to get adapter instance """
         module_name = "lib.db_adapters." + adapter_name
         class_name = adapter_name[0].upper() + adapter_name[1:]

--- a/lib/db_adapters/interface.py
+++ b/lib/db_adapters/interface.py
@@ -4,7 +4,7 @@
 import abc
 
 
-class AbstractAdapter(object, metaclass=abc.ABCMeta):
+class AbstractAdapter(abc.ABCMeta):
     def __init__(self, config):
         self.config = config
 


### PR DESCRIPTION
This is invalid syntax and is causing a revert of all new PRs. Fixing this should allow all new PRs to no longer be reverted.