### PR TITLE
remove broken auditing

### DIFF
--- a/startup.d/10-git-pull.sh
+++ b/startup.d/10-git-pull.sh
@@ -1,23 +1,3 @@
 #!/bin/sh
 
-# Prepare code auditing environment
-REPO_URL=$(git remote get-url origin)
-TEST_DIR=$(mktemp -d)
-git clone "$REPO_URL" "$TEST_DIR";
-pushd "$TEST_DIR";
-
-# Code auditing section
-find . -name '*.py' -print0 | xargs -0 python -m py_compile;
-if [ "$?" != "0" ]
-then
-  echo "There is syntax error. This may endanger chaos. Pauses updates."
-  rm -r -f "$TEST_DIR";
-  exit 45
-fi
-
-# End code auditing section
-popd
-rm -r -f "$TEST_DIR";
-
-git checkout master
 git pull


### PR DESCRIPTION
as seen by 
```
error: Unknown subcommand: get-url
usage: git remote [-v | --verbose]
   or: git remote add [-t <branch>] [-m <master>] [-f] [--tags|--no-tags] [--mirror=<fetch|push>] <name> <url>
   or: git remote rename <old> <new>
   or: git remote remove <name>
   or: git remote set-head <name> (-a | --auto | -d | --delete |<branch>)
   or: git remote [-v | --verbose] show [-n] <name>
   or: git remote prune [-n | --dry-run] <name>
   or: git remote [-v | --verbose] update [-p | --prune] [(<group> | <remote>)...]
   or: git remote set-branches [--add] <name> <branch>...
   or: git remote set-url [--push] <name> <newurl> [<oldurl>]
   or: git remote set-url --add <name> <newurl>
   or: git remote set-url --delete <name> <url>

    -v, --verbose         be verbose; must be placed before a subcommand

fatal: The empty string is not a valid path
startup.d/10-git-pull.sh: 7: startup.d/10-git-pull.sh: pushd: not found
startup.d/10-git-pull.sh: 19: startup.d/10-git-pull.sh: popd: not found
Already on 'master'
```

With travis implemented, this is not needed.