### PR TITLE
Fix meritocracy mentions and extended voting window

### DIFF
--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -79,16 +79,17 @@ CREATE TABLE IF NOT EXISTS meritocracy_mentioned (
             # the PR is mitigated or the threshold is not reached ?
             if variance >= threshold or not is_approved:
                 voting_window = gh.voting.get_extended_voting_window(api, settings.URN)
-                if vote_total >= threshold / 2:
+                if settings.IN_PRODUCTION and vote_total >= threshold / 2:
                     # check if we need to mention the meritocracy
                     try:
                         commit = pr["head"]["sha"]
                         if not db.query("SELECT * FROM meritocracy_mentioned WHERE commit_hash=?",
                                         (commit,)):
+                            meritocracy_mentions = meritocracy - {pr["user"]["login"].lower()}
                             db.query("INSERT INTO meritocracy_mentioned (commit_hash) VALUES (?)",
                                      (commit,))
                             gh.comments.leave_meritocracy_comment(api, settings.URN, pr["number"],
-                                                                  meritocracy)
+                                                                  meritocracy_mentions)
                     except:
                         __log.exception("Failed to process meritocracy mention")
 

--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS meritocracy_mentioned (
         __log.exception("Failed to create meritocracy mentioned DB table")
 
     # get voting window
-    voting_window = gh.voting.get_initial_voting_window()
+    base_voting_window = gh.voting.get_initial_voting_window()
 
     # get all ready prs (disregarding of the voting window)
     prs = gh.prs.get_ready_prs(api, settings.URN, 0)
@@ -76,16 +76,21 @@ CREATE TABLE IF NOT EXISTS meritocracy_mentioned (
             threshold = gh.voting.get_approval_threshold(api, settings.URN)
             is_approved = vote_total >= threshold and meritocracy_satisfied
 
+            seconds_since_updated = gh.prs.seconds_since_updated(api, pr)
+
+            voting_window = base_voting_window
             # the PR is mitigated or the threshold is not reached ?
             if variance >= threshold or not is_approved:
                 voting_window = gh.voting.get_extended_voting_window(api, settings.URN)
-                if settings.IN_PRODUCTION and vote_total >= threshold / 2:
+                if (settings.IN_PRODUCTION and vote_total >= threshold / 2 and
+                        seconds_since_updated > base_voting_window):
                     # check if we need to mention the meritocracy
                     try:
                         commit = pr["head"]["sha"]
                         if not db.query("SELECT * FROM meritocracy_mentioned WHERE commit_hash=?",
                                         (commit,)):
-                            meritocracy_mentions = meritocracy - {pr["user"]["login"].lower()}
+                            meritocracy_mentions = meritocracy - {pr["user"]["login"].lower(),
+                                                                  "chaosbot"}
                             db.query("INSERT INTO meritocracy_mentioned (commit_hash) VALUES (?)",
                                      (commit,))
                             gh.comments.leave_meritocracy_comment(api, settings.URN, pr["number"],
@@ -94,13 +99,13 @@ CREATE TABLE IF NOT EXISTS meritocracy_mentioned (
                         __log.exception("Failed to process meritocracy mention")
 
             # is our PR in voting window?
-            in_window = gh.prs.is_pr_in_voting_window(api, pr, voting_window)
+            in_window = seconds_since_updated > voting_window
 
             if is_approved:
                 __log.info("PR %d status: will be approved", pr_num)
 
                 gh.prs.post_accepted_status(
-                    api, settings.URN, pr, voting_window, votes, vote_total,
+                    api, settings.URN, pr, seconds_since_updated, voting_window, votes, vote_total,
                     threshold, meritocracy_satisfied)
 
                 if in_window:
@@ -134,8 +139,8 @@ CREATE TABLE IF NOT EXISTS meritocracy_mentioned (
 
                 if in_window:
                     gh.prs.post_rejected_status(
-                        api, settings.URN, pr, voting_window, votes, vote_total,
-                        threshold, meritocracy_satisfied)
+                        api, settings.URN, pr, seconds_since_updated, voting_window, votes,
+                        vote_total, threshold, meritocracy_satisfied)
                     __log.info("PR %d rejected, closing", pr_num)
                     gh.comments.leave_reject_comment(
                         api, settings.URN, pr_num, votes, vote_total, threshold,
@@ -144,12 +149,12 @@ CREATE TABLE IF NOT EXISTS meritocracy_mentioned (
                     gh.prs.close_pr(api, settings.URN, pr)
                 elif vote_total < 0:
                     gh.prs.post_rejected_status(
-                        api, settings.URN, pr, voting_window, votes, vote_total,
-                        threshold, meritocracy_satisfied)
+                        api, settings.URN, pr, seconds_since_updated, voting_window, votes,
+                        vote_total, threshold, meritocracy_satisfied)
                 else:
                     gh.prs.post_pending_status(
-                        api, settings.URN, pr, voting_window, votes, vote_total,
-                        threshold, meritocracy_satisfied)
+                        api, settings.URN, pr, seconds_since_updated, voting_window, votes,
+                        vote_total, threshold, meritocracy_satisfied)
 
             for user in votes:
                 if user in total_votes:

--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -83,7 +83,7 @@ CREATE TABLE IF NOT EXISTS meritocracy_mentioned (
             if variance >= threshold or not is_approved:
                 voting_window = gh.voting.get_extended_voting_window(api, settings.URN)
                 if (settings.IN_PRODUCTION and vote_total >= threshold / 2 and
-                        seconds_since_updated > base_voting_window):
+                        seconds_since_updated > base_voting_window and not meritocracy_satisfied):
                     # check if we need to mention the meritocracy
                     try:
                         commit = pr["head"]["sha"]

--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -271,17 +271,12 @@ def get_ready_prs(api, urn, window):
             handle_broken_pr(api, urn, pr, delta, "conflicts")
 
 
-def voting_window_remaining_seconds(api, pr, window):
+def seconds_since_updated(api, pr):
     now = arrow.utcnow()
     updated = get_pr_last_updated(api, pr)
     if updated is None:
         return math.inf
-    delta = (now - updated).total_seconds()
-    return window - delta
-
-
-def is_pr_in_voting_window(api, pr, window):
-    return voting_window_remaining_seconds(api, pr, window) <= 0
+    return (now - updated).total_seconds()
 
 
 def get_pr_reviews(api, urn, pr_num):
@@ -337,11 +332,11 @@ def get_patch(api, urn, pr_num, raw=False):
     return PatchSet(data)
 
 
-def post_accepted_status(api, urn, pr, voting_window, votes, total, threshold,
-                         meritocracy_satisfied):
+def post_accepted_status(api, urn, pr, seconds_since_updated, voting_window, votes, total,
+                         threshold, meritocracy_satisfied):
     sha = pr["head"]["sha"]
 
-    remaining_seconds = voting_window_remaining_seconds(api, pr, voting_window)
+    remaining_seconds = voting_window - seconds_since_updated
     remaining_human = misc.seconds_to_human(remaining_seconds)
     votes_summary = formatted_votes_short_summary(votes, total, threshold, meritocracy_satisfied)
 
@@ -349,11 +344,11 @@ def post_accepted_status(api, urn, pr, voting_window, votes, total, threshold,
                 "remaining: {time}, {summary}".format(time=remaining_human, summary=votes_summary))
 
 
-def post_rejected_status(api, urn, pr, voting_window, votes, total, threshold,
-                         meritocracy_satisfied):
+def post_rejected_status(api, urn, pr, seconds_since_updated, voting_window, votes, total,
+                         threshold, meritocracy_satisfied):
     sha = pr["head"]["sha"]
 
-    remaining_seconds = voting_window_remaining_seconds(api, pr, voting_window)
+    remaining_seconds = voting_window - seconds_since_updated
     remaining_human = misc.seconds_to_human(remaining_seconds)
     votes_summary = formatted_votes_short_summary(votes, total, threshold, meritocracy_satisfied)
 
@@ -361,11 +356,11 @@ def post_rejected_status(api, urn, pr, voting_window, votes, total, threshold,
                 "remaining: {time}, {summary}".format(time=remaining_human, summary=votes_summary))
 
 
-def post_pending_status(api, urn, pr, voting_window, votes, total, threshold,
-                        meritocracy_satisfied):
+def post_pending_status(api, urn, pr, seconds_since_updated, voting_window, votes, total,
+                        threshold, meritocracy_satisfied):
     sha = pr["head"]["sha"]
 
-    remaining_seconds = voting_window_remaining_seconds(api, pr, voting_window)
+    remaining_seconds = voting_window - seconds_since_updated
     remaining_human = misc.seconds_to_human(remaining_seconds)
     votes_summary = formatted_votes_short_summary(votes, total, threshold, meritocracy_satisfied)
 

--- a/settings.py
+++ b/settings.py
@@ -32,6 +32,10 @@ else:
 URN = misc.get_self_urn()
 GITHUB_USER, GITHUB_REPO = URN.split("/")
 
+# if we are running in production
+# if we switch to an org this will need changing
+IN_PRODUCTION = GITHUB_USER == "chaosbot"
+
 HOMEPAGE = "http://chaosthebot.com"
 
 # TEST SETTING PLEASE IGNORE


### PR DESCRIPTION
Now it must be running in production, and it will not mention the author of the PR (as they cannot review their own PR).

Edit: in addition, the PR must not be in the base voting window.