### PR TITLE
Fix ci failed label

### DIFF
--- a/github_api/prs.py
+++ b/github_api/prs.py
@@ -206,7 +206,7 @@ def has_build_failed(api, urn, ref):
     statuses = get_commit_statuses(api, urn, ref)
 
     for status in statuses:
-        if status["state"] in ["failure", "pending"] and \
+        if status["state"] in ["failure", "error"] and \
            status["context"].startswith(TRAVIS_CI_CONTEXT):
             return True
     return False

--- a/tests/github_api/prs_test.py
+++ b/tests/github_api/prs_test.py
@@ -65,7 +65,7 @@ class TestPRMethods(unittest.TestCase):
             self.assertTrue(prs.has_build_passed(self.api, "urn", "ref"))
             self.api.assert_called_once_with("get", "/repos/urn/commits/ref/status")
             self.api.reset_mock()
-            # Status returned success for travis - we know for sure it haven't failed
+            # Status returned success for travis - we know for sure it hasn't failed
             self.assertFalse(prs.has_build_failed(self.api, "urn", "ref"))
             self.api.assert_called_once_with("get", "/repos/urn/commits/ref/status")
             self.api.reset_mock()
@@ -76,17 +76,17 @@ class TestPRMethods(unittest.TestCase):
                      [{"state": "failure",
                        "context": "continuous-integration/travis-ci/pr"}],
                      # Travis pending
-                     [{"state": "pending",
+                     [{"state": "error",
                        "context": "continuous-integration/travis-ci/pr"}]
                      ]
 
         for statuses in test_data:
             self.api.return_value = {"statuses": statuses}
-            # Status returned failure or pending for travis - we know for sure it haven't suceeded
+            # Status returned failure or error for travis - we know for sure it hasn't suceeded
             self.assertFalse(prs.has_build_passed(self.api, "urn", "ref"))
             self.api.assert_called_once_with("get", "/repos/urn/commits/ref/status")
             self.api.reset_mock()
-            # Status returned failure or pending for travis - we know for sure it failed
+            # Status returned failure or error for travis - we know for sure it failed
             self.assertTrue(prs.has_build_failed(self.api, "urn", "ref"))
             self.api.assert_called_once_with("get", "/repos/urn/commits/ref/status")
             self.api.reset_mock()


### PR DESCRIPTION
Currently it gets added then removed as soon as a PR is created. That's because the current code sees pending (Travis is still running) as failing.