### PR TITLE
Make docker scripts current directory independent

### DIFF
--- a/dev/docker/build.bat
+++ b/dev/docker/build.bat
@@ -1,3 +1,4 @@
+cd %~dp0
 copy ..\..\requirements.txt .
 docker build -t chaos .
 del requirements.txt

--- a/dev/docker/build.sh
+++ b/dev/docker/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(dirname "$0")"
+
 while getopts ":rpi:" opt; do
 	case $opt in
 		\?)

--- a/dev/docker/run.bat
+++ b/dev/docker/run.bat
@@ -1,2 +1,2 @@
-cd ..\..\
+cd %~dp0\..\..\
 docker run -it --rm -v %cd%:/root/workspace/Chaos -p 8082:80 -p 8081:8081 chaos bash /root/workspace/Chaos/dev/docker/start_services.sh

--- a/dev/docker/run.sh
+++ b/dev/docker/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd "$(dirname "$0")"
 docker run -it --rm\
     -v $(cd ../../; pwd):/root/workspace/Chaos\
     -p 8082:80\

--- a/dev/docker/test.bat
+++ b/dev/docker/test.bat
@@ -1,2 +1,2 @@
-cd ..\..\
+cd %~dp0\..\..\
 docker run -it --rm -v %cd%:/root/workspace/Chaos -p 8082:80 -p 8081:8081 chaos bash /root/workspace/Chaos/dev/docker/start_tests.sh

--- a/dev/docker/test.sh
+++ b/dev/docker/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+cd "$(dirname "$0")"
 docker run -it --rm\
     -v $(cd ../../; pwd):/root/workspace/Chaos\
     -p 8082:80\


### PR DESCRIPTION
Instead of `cd dev/docker; sudo ./run.sh` this allows `sudo dev/docker/run.sh`.