### PR TITLE
Prevent e  beach from joining the meritocracy through voting

### DIFF
--- a/cron/poll_pull_requests.py
+++ b/cron/poll_pull_requests.py
@@ -56,7 +56,10 @@ CREATE TABLE IF NOT EXISTS meritocracy_mentioned (
         top_contributors = top_contributors[:settings.MERITOCRACY_TOP_CONTRIBUTORS]
         top_contributors = set(top_contributors)
         top_voters = sorted(total_votes, key=total_votes.get, reverse=True)
-        top_voters = set([user.lower() for user in top_voters[:settings.MERITOCRACY_TOP_VOTERS]])
+        top_voters = map(lambda user: user.lower(), top_voters)
+        top_voters = list(filter(lambda user: user not in settings.MERITOCRACY_VOTERS_BLACKLIST,
+                                 top_voters))
+        top_voters = set(top_voters[:settings.MERITOCRACY_TOP_VOTERS])
         meritocracy = top_voters | top_contributors
         __log.info("generated meritocracy: " + str(meritocracy))
 

--- a/settings.py
+++ b/settings.py
@@ -114,6 +114,11 @@ MERITOCRACY_TOP_CONTRIBUTORS = 10
 # The top n voters will be allowed in the meritocracy
 MERITOCRACY_TOP_VOTERS = 10
 
+# These users are not allowed in the meritorcracy through being a top voter
+MERITOCRACY_VOTERS_BLACKLIST = {"e-beach"}
+# Make sure usernames are lowercased
+MERITOCRACY_VOTERS_BLACKLIST = {user.lower() for user in MERITOCRACY_VOTERS_BLACKLIST}
+
 # Database settings
 DB_ADAPTER = "sqlite"
 DB_CONFIG = {


### PR DESCRIPTION
I'm 90% sure e  beach is using a bot to upvote every PR, and is hoping to get into the meritocracy that way (I'm purposely not mentioning him).

This is more of a patch to stem the issue until a better solution gets developed (e.g. counting comments and issues created by users).

I'll blacklist chaosbot from the meritocracy in another PR, but I'll let #500 merge first. That blacklists chaosbot from meritocracy mentions, and I'd prefer not to have two blacklists in place.