### PR TITLE
Add emojis to issue command status

### DIFF
--- a/cron/poll_issue_close_stale.py
+++ b/cron/poll_issue_close_stale.py
@@ -34,6 +34,6 @@ def poll_issue_close_stale(api):
             __log.info("/vote close issue %d" % number)
 
             # leave an explanatory comment
-            body = "/vote close \n\nThis issue hasn't been active for a while." + \
+            body = "/vote close \n\nThis issue hasn't been active for a while. " + \
                 "To keep it open, react with :-1:"
             gh.comments.leave_comment(api, settings.URN, number, body)

--- a/cron/poll_read_issue_comments.py
+++ b/cron/poll_read_issue_comments.py
@@ -162,7 +162,7 @@ def post_command_status_update(api, issue_id, comment_id, has_votes):
     command_text = comment_data["command"]
 
     time = gh.misc.seconds_to_human(seconds_remaining)
-    status = "passing" if has_votes else "failing"
+    status = "passing :white_check_mark:" if has_votes else "failing :no_entry:"
     body = "> {command}\n\nTime remaining: {time} - Vote status: {status}".format(
                                                                             command=command_text,
                                                                             time=time,


### PR DESCRIPTION
This will use the ✅  emoji for passing statuses, and ⛔️  emoji for failing statuses. This will just liven up the comments a bit and make them easier to see on first glance.