### PR TITLE
Fully deprecate old web server and fix new one

### DIFF
--- a/chaos.py
+++ b/chaos.py
@@ -81,6 +81,7 @@ def main():
                       "--socket", "127.0.0.1:8085",
                       "--wsgi-file", "webserver.py",
                       "--callable", "__hug_wsgi__",
+                      "--check-static", "/root/workspace/Chaos/server/",
                       "--daemonize", "/root/workspace/Chaos/log/uwsgi.log"])
 
     # Schedule all cron jobs to be run

--- a/chaos.py
+++ b/chaos.py
@@ -81,7 +81,6 @@ def main():
                       "--socket", "127.0.0.1:8085",
                       "--wsgi-file", "webserver.py",
                       "--callable", "__hug_wsgi__",
-                      "--check-static", "/root/workspace/Chaos/server",
                       "--daemonize", "/root/workspace/Chaos/log/uwsgi.log"])
 
     # Schedule all cron jobs to be run

--- a/etc/nginx/chaos_uwsgi
+++ b/etc/nginx/chaos_uwsgi
@@ -6,14 +6,13 @@ server {
     server_name 0.0.0.0;
 
     root /root/workspace/Chaos/server;
-    index index.html index.htm;
 
-    error_page 400 403 404 407 500 502 503 504 /api/errorpage?status=$status;
+    error_page 400 403 404 407 500 502 503 504 /api/errorpage?code=$status;
 
-    location /api {
+    location / {
         include uwsgi_params;
+        index index.html;
+        uwsgi_intercept_errors on;
         uwsgi_pass 127.0.0.1:8085;
-        uwsgi_param SCRIPT_NAME /api;
-        uwsgi_modifier1 30;
     }
 }

--- a/etc/nginx/chaos_uwsgi
+++ b/etc/nginx/chaos_uwsgi
@@ -8,8 +8,12 @@ server {
     root /root/workspace/Chaos/server;
     index index.html index.htm;
 
-    location / {
+    error_page 400 403 404 407 500 502 503 504 /api/errorpage?status=$status;
+
+    location /api {
         include uwsgi_params;
         uwsgi_pass 127.0.0.1:8085;
+        uwsgi_param SCRIPT_NAME /api;
+        uwsgi_modifier1 30;
     }
 }

--- a/server/voters.html
+++ b/server/voters.html
@@ -17,7 +17,7 @@
                 var result = document.getElementById("result");
                 // read text from URL location
                 var request = new XMLHttpRequest();
-                request.open('GET', 'voters', true);
+                request.open('GET', 'api/voters', true);
                 request.send(null);
                 request.onreadystatechange = function() {
                     if (request.readyState === 4 && request.status === 200) {

--- a/startup.d/70-webserver.sh
+++ b/startup.d/70-webserver.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+pkill chaos_server
+
+chmod -R a+rX server/
+
+nginx -t
+service nginx force-reload

--- a/startup.d/70-webserver.sh
+++ b/startup.d/70-webserver.sh
@@ -2,8 +2,8 @@
 
 pkill chaos_server
 
-ln -f /var/log/nginx/access.log /root/workspace/Chaos/log/nginx-access.log
-ln -f /var/log/nginx/error.log /root/workspace/Chaos/log/nginx-error.log
+ln -sf /var/log/nginx/access.log /root/workspace/Chaos/log/nginx-access.log
+ln -sf /var/log/nginx/error.log /root/workspace/Chaos/log/nginx-error.log
 
 nginx -t
 service nginx force-reload

--- a/startup.d/70-webserver.sh
+++ b/startup.d/70-webserver.sh
@@ -2,7 +2,8 @@
 
 pkill chaos_server
 
-chmod -R a+rX server/
+ln -f /var/log/nginx/access.log /root/workspace/Chaos/log/nginx-access.log
+ln -f /var/log/nginx/error.log /root/workspace/Chaos/log/nginx-error.log
 
 nginx -t
 service nginx force-reload

--- a/webserver.py
+++ b/webserver.py
@@ -2,15 +2,29 @@ import hug
 import json
 import linecache
 import logging
+from http import server
 
 
 __log = logging.getLogger("webserver")
+responses = server.BaseHTTPRequestHandler.responses
+
 index_content = open("/root/workspace/Chaos/server/index.html", "r").read()
+errorpage_content = open("/root/workspace/Chaos/server/error.html", "r").read()
 
 
 @hug.get("/", output=hug.output_format.html)
 def render_index():
     return index_content
+
+
+@hug.get("/api/errorpage", output=hug.output_format.html)
+def render_error(code: hug.types.number = 500):
+    status = responses[code]
+    return errorpage_content % {
+        "code": code,
+        "message": status[0],
+        "explain": status[1]
+    }
 
 
 @hug.get("/api/voters", examples=["amount=20", "amount=0"])

--- a/webserver.py
+++ b/webserver.py
@@ -9,11 +9,11 @@ index_content = open("/root/workspace/Chaos/server/index.html", "r").read()
 
 
 @hug.get("/", output=hug.output_format.html)
-def get_index():
+def render_index():
     return index_content
 
 
-@hug.get("/voters", examples=["amount=20", "amount=0"])
+@hug.get("/api/voters", examples=["amount=20", "amount=0"])
 def get_voters(amount: hug.types.number = 20):
     try:
         voters = sorted(json.loads(
@@ -26,7 +26,7 @@ def get_voters(amount: hug.types.number = 20):
         __log.exception("Failed to read voters!")
 
 
-@hug.get("/meritocracy", examples=["amount=5", "amount=0"])
+@hug.get("/api/meritocracy", examples=["amount=5", "amount=0"])
 def get_meritocracy(amount: hug.types.number = 20):
     try:
         meritocracy = json.loads(


### PR DESCRIPTION
* Move API endpoints to `/api/`
* Reintroduce error page rendering
* Kill old web server, just in case it's still running
* Reload nginx when updating ChaosBot to ensure that configs are reloaded