### PR TITLE
Ignore neutral reviews

### DIFF
--- a/github_api/voting.py
+++ b/github_api/voting.py
@@ -107,7 +107,8 @@ def get_pr_review_reactions(api, urn, pr):
         user = review["user"]["login"]
         is_current = review["commit_id"] == pr["head"]["sha"]
         vote = parse_review_for_vote(state)
-        yield user, is_current, vote
+        if vote != 0:
+            yield user, is_current, vote
 
 
 def get_vote_weight(api, username, contributors):


### PR DESCRIPTION
Currently a neutral review (the default when you use "add single comment" instead of "start a review") will override an approval. This PR makes chaosbot ignore netural reviews, so they don't override positive reviews. A positive review can still be overriden with a negative review (which currently is treated the same as no review at all).