### PR TITLE
Update comment in chaos_wrapper.sh after changes of #418

### DIFF
--- a/chaos_wrapper.sh
+++ b/chaos_wrapper.sh
@@ -17,7 +17,7 @@ function rollback() {
     supervisorctl update
 }
 
-# time the chaos server... if it crashes in 60s, then attempt a rollback
+# time the chaos server... if it crashes before 15 minutes, then attempt a rollback
 start_time=`date +%s`
 /root/.virtualenvs/chaos/bin/python chaos.py
 failed=$?


### PR DESCRIPTION
#418 changed the time threshold for rolling back changes. However, the corresponding comment was not updated to reflect this.

This PR adjusts the comment of chaos_wrapper.sh to fix this.