### PR TITLE
HOTFIX - vote spam

### DIFF
--- a/cron/poll_read_issue_comments.py
+++ b/cron/poll_read_issue_comments.py
@@ -241,7 +241,12 @@ def poll_read_issue_comments(api):
             # Get info and store in db
             # Do a check to make sure comment_id isn't a command that already ran
             if is_command(issue_comment["comment_text"]):
-                insert_or_update(api, issue_comment)
+                _id = issue_comment["global_comment_id"]
+                # HOTFIX to not re-add command if it was already ran.
+                try:
+                    InactiveIssueCommands.get(comment=_id)
+                except InactiveIssueCommands.DoesNotExist:
+                    insert_or_update(api, issue_comment)
 
     cmds = ActiveIssueCommands.select().order_by(ActiveIssueCommands.seconds_remaining)
     for cmd in cmds:


### PR DESCRIPTION
This is a hotfix to help stop the vote spam we are seeing. Here's how it works.

1. A command is identified and ran
2. The command is then put into the InactiveCommands table to signify it ran

The previous problem was that when identifying new commands, we didn't check if it was already in the inactive commands list.

What does this PR solve? Well it won't re-add commands to the db to be run. HOWEVER it won't solve the problem if there is an issue removing commands from the ActiveCommand table.

Either way, this check needs to be in.

Also, my apologies for the goof. I thought I had tested pretty well but something must have slipped through the cracks.