### PR TITLE
Fix voters HTML

### DIFF
--- a/server/voters.html
+++ b/server/voters.html
@@ -45,7 +45,7 @@
 
                             var tablehtml = "<table>";
                             for (var i = 0; i < list.length; i++) {
-                                tablehtml += "<tr><td><a href=\"https://github.com/" + escape(list[i].names) + "\">" + list[i].names + "</a></td><td>" + list[i].votes + "</tr>";
+                                tablehtml += "<tr><td><a href=\"https://github.com/" + escape(list[i].names) + "\">" + list[i].names + "</a></td><td>" + list[i].votes + "</td></tr>";
                             }
                             tablehtml += "</table>";
                             result.innerHTML = tablehtml;


### PR DESCRIPTION
This adds a missing closing `</td>` tag in the votes column of the table. Doesn't cause any issues on modern browsers, but could have been a problem in older browsers.