### PR TITLE
Relax ESLint rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,6 @@
 root = true
 
 [*]
-indent_style = space
-indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 end_of_line = lf

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,16 @@
 {
     "extends": "eslint:recommended",
     "env": {
+        "es6": true,
         "browser": true,
         "jquery": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": true
+        }
     },
     "plugins": [
         "jquery"

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,6 @@
         "jquery"
     ],
     "rules": {
-        "quotes": ["error", "double", {"allowTemplateLiterals": true}],
         "no-console": "off",
         "no-mixed-operators": "off"
     }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-    "extends": "airbnb",
+    "extends": "eslint:recommended",
     "env": {
         "browser": true,
         "jquery": true
@@ -9,7 +9,6 @@
     ],
     "rules": {
         "quotes": ["error", "double", {"allowTemplateLiterals": true}],
-        "indent": ["error", 4],
         "no-console": "off",
         "no-mixed-operators": "off"
     }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 install:
   - "nvm install node"
   - "nvm use node"
-  - "npm install -g eslint@^3.19.0 eslint-plugin-jquery@latest eslint-plugin-jsx-a11y@^5.0.1 eslint-plugin-import@^2.2.0 eslint-plugin-react@^7.0.1 eslint-config-airbnb"
+  - "npm install -g eslint@^3.19.0 eslint-plugin-jquery@latest eslint-plugin-jsx-a11y@^5.0.1 eslint-plugin-import@^2.2.0 eslint-plugin-react@^7.0.1"
   - "pip install -r requirements.txt"
   - "pip install flake8"
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 install:
   - "nvm install node"
   - "nvm use node"
-  - "npm install -g eslint@^3.19.0 eslint-plugin-jquery@latest eslint-plugin-jsx-a11y@^5.0.1 eslint-plugin-import@^2.2.0 eslint-plugin-react@^7.0.1"
+  - "npm install -g eslint@^3.19.0 eslint-plugin-jquery@latest eslint-plugin-import@^2.2.0"
   - "pip install -r requirements.txt"
   - "pip install flake8"
 cache: pip


### PR DESCRIPTION
Those are too restrict. It's not good for chaos. **We need chaos.**
Changed airbnb to eslint:recommended, which is not too strict.
As documented [here](http://eslint.org/docs/rules/) it "report common problems" instead of enforcing a specific code style.